### PR TITLE
Allow Pokemon/PvP specific city subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,7 @@ config.json
 logs
 
 # No geofences
-#geofences/*
+geofences/*
 
 # No icons
 static/img/pokemon/

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -61,8 +61,8 @@
     ],
     "urls": {
         "images": {
-            "pokemon": "https://cdn.example.com/images/original/monsters/%s_%s.png",
-            "eggs": "../img/original/eggs/%s.png"
+            "pokemon": "https://mygod.github.io/pokicons/v2",
+            "eggs": "/img/eggs/%s.png"
         },
         "map": "",
         "paypal": ""

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -1,27 +1,27 @@
 'use strict';
 
-const locale = require('../services/locale.js');
-const utils = require('../services/utils.js');
+const Localizer = require('../services/locale.js');
 const GeofenceService = require('../services/geofence.js');
 
 const svc = new GeofenceService.GeofenceService();
 const config = require('../config.json');
 const grunttypes = require('../../static/data/grunttype.json');
 
-const getPokemonNameIdsList = () => {
+const getPokemonNameIdsList = async () => {
     let pokemon = [];
     for (let i = 1; i < config.maxPokemonId; i++) {
+        const pkmnIcon = await Localizer.instance.getPokemonIcon(i);
         pokemon.push({
             'id': i,
             'id_3': (i + '').padStart(3, '0'),
-            'name': locale.getPokemonName(i),
-            'image_url': utils.getPokemonIcon(i, 0)
+            'name': Localizer.instance.getPokemonName(i),
+            'image_url': pkmnIcon,
         });
     }
     return pokemon;
 };
 
-const getGruntRewardIdsList = () => {
+const getGruntRewardIdsList = async () => {
     const grunts = grunttypes;
     const rewards = [];
     const keys = Object.keys(grunts);
@@ -36,11 +36,12 @@ const getGruntRewardIdsList = () => {
                 if (exists.length > 0) {
                     continue;
                 }
+                const pkmnIcon = await Localizer.instance.getPokemonIcon(pokemonId);
                 rewards.push({
                     'pokemon_id': pokemonId,
                     'pokemon_id_3': (pokemonId + '').padStart(3, '0'),
-                    'name': locale.getPokemonName(pokemonId),
-                    'image_url': utils.getPokemonIcon(pokemonId, 0)
+                    'name': Localizer.instance.getPokemonName(pokemonId),
+                    'image_url': pkmnIcon,
                 });
             }
             if (grunt.second_reward) {
@@ -51,11 +52,12 @@ const getGruntRewardIdsList = () => {
                     if (exists.length > 0) {
                         continue;
                     }
+                    const pkmnIcon = await Localizer.instance.getPokemonIcon(pokemonId);
                     rewards.push({
                         'pokemon_id': pokemonId,
                         'pokemon_id_3': (pokemonId + '').padStart(3, '0'),
-                        'name': locale.getPokemonName(pokemonId),
-                        'image_url': utils.getPokemonIcon(pokemonId, 0)
+                        'name': Localizer.instance.getPokemonName(pokemonId),
+                        'image_url': pkmnIcon,
                     });
                 }
             }
@@ -75,7 +77,7 @@ const buildCityList = (guilds) => {
             if (guilds.includes(configGuild.id) && configGuild.geofences.includes(geofence.name)) {
                 cities.push({
                     'name': geofence.name,
-                    'guild': configGuild.id
+                    'guild': configGuild.id,
                 });
             }
         }

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -10,11 +10,11 @@ const grunttypes = require('../../static/data/grunttype.json');
 const getPokemonNameIdsList = async () => {
     let pokemon = [];
     for (let i = 1; i < config.maxPokemonId; i++) {
-        const pkmnIcon = await Localizer.instance.getPokemonIcon(i);
+        const pkmnIcon = await Localizer.getPokemonIcon(i);
         pokemon.push({
             'id': i,
             'id_3': (i + '').padStart(3, '0'),
-            'name': Localizer.instance.getPokemonName(i),
+            'name': Localizer.getPokemonName(i),
             'image_url': pkmnIcon,
         });
     }
@@ -36,11 +36,11 @@ const getGruntRewardIdsList = async () => {
                 if (exists.length > 0) {
                     continue;
                 }
-                const pkmnIcon = await Localizer.instance.getPokemonIcon(pokemonId);
+                const pkmnIcon = await Localizer.getPokemonIcon(pokemonId);
                 rewards.push({
                     'pokemon_id': pokemonId,
                     'pokemon_id_3': (pokemonId + '').padStart(3, '0'),
-                    'name': Localizer.instance.getPokemonName(pokemonId),
+                    'name': Localizer.getPokemonName(pokemonId),
                     'image_url': pkmnIcon,
                 });
             }
@@ -52,11 +52,11 @@ const getGruntRewardIdsList = async () => {
                     if (exists.length > 0) {
                         continue;
                     }
-                    const pkmnIcon = await Localizer.instance.getPokemonIcon(pokemonId);
+                    const pkmnIcon = await Localizer.getPokemonIcon(pokemonId);
                     rewards.push({
                         'pokemon_id': pokemonId,
                         'pokemon_id_3': (pokemonId + '').padStart(3, '0'),
-                        'name': Localizer.instance.getPokemonName(pokemonId),
+                        'name': Localizer.getPokemonName(pokemonId),
                         'image_url': pkmnIcon,
                     });
                 }

--- a/src/data/subscriptions.js
+++ b/src/data/subscriptions.js
@@ -101,7 +101,7 @@ const getPokemonSubscriptions = async (guildId, userId) => {
             result.iv = result.min_iv;
             result.iv_list = JSON.parse(result.iv_list || '[]');
             result.lvl = `${result.min_lvl}-${result.max_lvl}`;
-            //result.city = result.city;
+            result.city = JSON.parse(result.city || '[]');
         });
     }
     return results;
@@ -119,7 +119,7 @@ const getPvpSubscriptions = async (guildId, userId) => {
         results.forEach(result => {
             result.name = locale.getPokemonName(result.pokemon_id);
             //result.min_rank = result.min_rank;
-            //result.city = result.city;
+            result.city = JSON.parse(result.city || '[]');
         });
     }
     return results;
@@ -136,6 +136,7 @@ const getRaidSubscriptions = async (guildId, userId) => {
     if (results) {
         results.forEach(result => {
             result.name = locale.getPokemonName(result.pokemon_id);
+            result.city = JSON.parse(result.city || '[]');
         });
     }
     return results;
@@ -160,6 +161,11 @@ const getQuestSubscriptions = async (guildId, userId) => {
     `;
     const args = [guildId, userId];
     const results = await db.query(sql, args);
+    if (results) {
+        results.forEach(result => {
+            result.city = JSON.parse(result.city || '[]');
+        });
+    }
     return results;
 };
 
@@ -174,6 +180,7 @@ const getInvasionSubscriptions = async (guildId, userId) => {
     if (results) {
         results.forEach(result => {
             result.reward = locale.getPokemonName(result.reward_pokemon_id);
+            result.city = JSON.parse(result.city || '[]');
         });
     }
     return results;

--- a/src/data/subscriptions.js
+++ b/src/data/subscriptions.js
@@ -96,7 +96,7 @@ const getPokemonSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.name = Localizer.instance.getPokemonName(result.pokemon_id);
+            result.name = Localizer.getPokemonName(result.pokemon_id);
             result.cp = `${result.min_cp}-4096`;
             result.iv = result.min_iv;
             result.iv_list = JSON.parse(result.iv_list || '[]');
@@ -117,7 +117,7 @@ const getPvpSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.name = Localizer.instance.getPokemonName(result.pokemon_id);
+            result.name = Localizer.getPokemonName(result.pokemon_id);
             //result.min_rank = result.min_rank;
             result.city = JSON.parse(result.city || '[]');
         });
@@ -135,7 +135,7 @@ const getRaidSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.name = Localizer.instance.getPokemonName(result.pokemon_id);
+            result.name = Localizer.getPokemonName(result.pokemon_id);
             result.city = JSON.parse(result.city || '[]');
         });
     }
@@ -179,7 +179,7 @@ const getInvasionSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.reward = Localizer.instance.getPokemonName(result.reward_pokemon_id);
+            result.reward = Localizer.getPokemonName(result.reward_pokemon_id);
             result.city = JSON.parse(result.city || '[]');
         });
     }

--- a/src/data/subscriptions.js
+++ b/src/data/subscriptions.js
@@ -3,7 +3,7 @@
 const config = require('../config.json');
 const MySQLConnector = require('../services/mysql.js');
 const db = new MySQLConnector(config.db.brock);
-const locale = require('../services/locale.js');
+const Localizer = require('../services/locale.js');
 
 // TODO: Move to model classes
 
@@ -96,7 +96,7 @@ const getPokemonSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.name = locale.getPokemonName(result.pokemon_id);
+            result.name = Localizer.instance.getPokemonName(result.pokemon_id);
             result.cp = `${result.min_cp}-4096`;
             result.iv = result.min_iv;
             result.iv_list = JSON.parse(result.iv_list || '[]');
@@ -117,7 +117,7 @@ const getPvpSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.name = locale.getPokemonName(result.pokemon_id);
+            result.name = Localizer.instance.getPokemonName(result.pokemon_id);
             //result.min_rank = result.min_rank;
             result.city = JSON.parse(result.city || '[]');
         });
@@ -135,7 +135,7 @@ const getRaidSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.name = locale.getPokemonName(result.pokemon_id);
+            result.name = Localizer.instance.getPokemonName(result.pokemon_id);
             result.city = JSON.parse(result.city || '[]');
         });
     }
@@ -179,7 +179,7 @@ const getInvasionSubscriptions = async (guildId, userId) => {
     const results = await db.query(sql, args);
     if (results) {
         results.forEach(result => {
-            result.reward = locale.getPokemonName(result.reward_pokemon_id);
+            result.reward = Localizer.instance.getPokemonName(result.reward_pokemon_id);
             result.city = JSON.parse(result.city || '[]');
         });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const utils = require('./services/utils.js');
 // TODO: Disable server selector when in edit pages
 // TODO: Add proper error messages
 // TODO: Add checkbox to only show available invasion rewards
+// TODO: Lookup form name to id and show proper icon
 
 (async () => {
     // Basic security protections

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ const utils = require('./services/utils.js');
 // TODO: Copy subscriptions to other discord server options
 // TODO: Cookie sessions
 // TODO: Disable server selector when in edit pages
-// TODO: Display all Pokemon for invasions not just what's available
+// TODO: Add proper error messages
+// TODO: Add checkbox to only show available invasion rewards
 
 (async () => {
     // Basic security protections

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const utils = require('./services/utils.js');
 // TODO: Copy subscriptions to other discord server options
 // TODO: Cookie sessions
 // TODO: Disable server selector when in edit pages
+// TODO: Display all Pokemon for invasions not just what's available
 
 (async () => {
     // Basic security protections

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,8 @@ const utils = require('./services/utils.js');
 // TODO: Update insert if already exists update
 // TODO: Cookie sessions
 
-// TODO: Change Edit pages to allow multiple city selection
 // TODO: Disable server selector when in edit pages
+// TODO: Check if subscribed cities are for all available, if so show `All` instead of list of cities
 
 (async () => {
     // Basic security protections

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,9 @@ const utils = require('./services/utils.js');
 // TODO: Update insert if already exists update
 // TODO: Cookie sessions
 
+// TODO: Change Edit pages to allow multiple city selection
+// TODO: Disable server selector when in edit pages
+
 (async () => {
     // Basic security protections
     app.use(helmet());

--- a/src/index.js
+++ b/src/index.js
@@ -18,15 +18,11 @@ const discordRoutes = require('./routes/discord.js');
 const uiRoutes = require('./routes/ui.js');
 const utils = require('./services/utils.js');
 
-// TODO: Group quests and invasion cities when listing
 // TODO: Convert to typescript
 // TODO: Import/export options
 // TODO: Copy subscriptions to other discord server options
-// TODO: Update insert if already exists update
 // TODO: Cookie sessions
-
 // TODO: Disable server selector when in edit pages
-// TODO: Check if subscribed cities are for all available, if so show `All` instead of list of cities
 
 (async () => {
     // Basic security protections

--- a/src/models/gym.js
+++ b/src/models/gym.js
@@ -119,17 +119,17 @@ class Gym {
         return result.affectedRows > 0;
     }
 
-    static async save(id, guildId, userId, name) {
+    async save() {
         const sql = `
         UPDATE gyms
         SET name = ?
         WHERE guild_id = ? AND user_id = ? AND id = ?
         `;
         const args = [
-            name,
-            guildId,
-            userId,
-            id
+            this.name,
+            this.guildId,
+            this.userId,
+            this.id
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;

--- a/src/models/invasion.js
+++ b/src/models/invasion.js
@@ -80,7 +80,7 @@ class Invasion {
         WHERE guild_id = ? AND user_id = ? AND reward_pokemon_id = ?
         LIMIT 1
         `;
-        const args = [guildId, userId, reward, city];
+        const args = [guildId, userId, reward];
         const results = await db.query(sql, args);
         if (results && results.length > 0) {
             const result = results[0];

--- a/src/models/invasion.js
+++ b/src/models/invasion.js
@@ -21,7 +21,8 @@ class Invasion {
         const args = [
             this.subscriptionId,
             this.guildId, this.userId,
-            this.rewardPokemonId, this.city
+            this.rewardPokemonId,
+            JSON.stringify(this.city || []),
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;
@@ -43,7 +44,7 @@ class Invasion {
                     result.guild_id,
                     result.user_id,
                     result.reward_pokemon_id,
-                    result.city
+                    JSON.parse(result.city || '[]'),
                 ));
             });
             return list;
@@ -66,17 +67,17 @@ class Invasion {
                 result.guild_id,
                 result.user_id,
                 result.reward_pokemon_id,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
     }
 
-    static async getByReward(guildId, userId, reward, city) {
+    static async getByReward(guildId, userId, reward) {
         const sql = `
         SELECT subscription_id, guild_id, user_id, reward_pokemon_id, city
         FROM invasions
-        WHERE guild_id = ? AND user_id = ? AND reward_pokemon_id = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND reward_pokemon_id = ?
         LIMIT 1
         `;
         const args = [guildId, userId, reward, city];
@@ -88,18 +89,18 @@ class Invasion {
                 result.guild_id,
                 result.user_id,
                 result.reward_pokemon_id,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
     }
     
-    static async delete(guildId, userId, rewardPokemonId, city) {
+    static async delete(guildId, userId, rewardPokemonId) {
         const sql = `
         DELETE FROM invasions
-        WHERE guild_id = ? AND user_id = ? AND reward_pokemon_id = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND reward_pokemon_id = ?
         `;
-        const args = [guildId, userId, rewardPokemonId, city];
+        const args = [guildId, userId, rewardPokemonId];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;
     }
@@ -132,7 +133,7 @@ class Invasion {
         `;
         const args = [
             reward,
-            city,
+            JSON.stringify(city),
             guildId,
             userId,
             id

--- a/src/models/invasion.js
+++ b/src/models/invasion.js
@@ -5,7 +5,8 @@ const MySQLConnector = require('../services/mysql.js');
 const db = new MySQLConnector(config.db.brock);
 
 class Invasion {
-    constructor(subscriptionId, guildId, userId, rewardPokemonId, city) {
+    constructor(id, subscriptionId, guildId, userId, rewardPokemonId, city) {
+        this.id = id;
         this.subscriptionId = subscriptionId;
         this.guildId = guildId;
         this.userId = userId;
@@ -20,7 +21,8 @@ class Invasion {
         `;
         const args = [
             this.subscriptionId,
-            this.guildId, this.userId,
+            this.guildId,
+            this.userId,
             this.rewardPokemonId,
             JSON.stringify(this.city || []),
         ];
@@ -30,7 +32,7 @@ class Invasion {
 
     static async getAll(guildId, userId) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, reward_pokemon_id, city
+        SELECT id, subscription_id, guild_id, user_id, reward_pokemon_id, city
         FROM invasions
         WHERE guild_id = ? AND user_id = ?
         `;
@@ -40,6 +42,7 @@ class Invasion {
             const list = [];
             results.forEach(result => {
                 list.push(new Invasion(
+                    result.id,
                     result.subscription_id,
                     result.guild_id,
                     result.user_id,
@@ -54,7 +57,7 @@ class Invasion {
 
     static async getById(id) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, reward_pokemon_id, city
+        SELECT id, subscription_id, guild_id, user_id, reward_pokemon_id, city
         FROM invasions
         WHERE id = ?
         `;
@@ -63,6 +66,7 @@ class Invasion {
         if (results && results.length > 0) {
             const result = results[0];
             return new Invasion(
+                result.id,
                 result.subscription_id,
                 result.guild_id,
                 result.user_id,
@@ -75,7 +79,7 @@ class Invasion {
 
     static async getByReward(guildId, userId, reward) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, reward_pokemon_id, city
+        SELECT id, subscription_id, guild_id, user_id, reward_pokemon_id, city
         FROM invasions
         WHERE guild_id = ? AND user_id = ? AND reward_pokemon_id = ?
         LIMIT 1
@@ -85,6 +89,7 @@ class Invasion {
         if (results && results.length > 0) {
             const result = results[0];
             return new Invasion(
+                result.id,
                 result.subscription_id,
                 result.guild_id,
                 result.user_id,
@@ -125,18 +130,18 @@ class Invasion {
         return result.affectedRows > 0;
     }
 
-    static async save(id, guildId, userId, reward, city) {
+    async save() {
         const sql = `
         UPDATE invasions
         SET reward_pokemon_id = ?, city = ?
         WHERE guild_id = ? AND user_id = ? AND id = ?
         `;
         const args = [
-            reward,
-            JSON.stringify(city),
-            guildId,
-            userId,
-            id
+            this.rewardPokemonId,
+            JSON.stringify(this.city),
+            this.guildId,
+            this.userId,
+            this.id
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -159,25 +159,25 @@ class Pokemon {
         return result.affectedRows > 0;
     }
 
-    static async save(id, guildId, userId, pokemonId, form, minCP, minIV, ivList, minLvl, maxLvl, gender, city) {
+    async save() {
         const sql = `
         UPDATE pokemon
         SET pokemon_id = ?, form = ?, min_cp = ?, min_iv = ?, iv_list = ?, min_lvl = ?, max_lvl = ?, gender = ?, city = ?
         WHERE guild_id = ? AND user_id = ? AND id = ?
         `;
         const args = [
-            pokemonId,
-            form,
-            minCP,
-            minIV,
-            JSON.stringify(ivList),
-            minLvl,
-            maxLvl,
-            gender,
-            JSON.stringify(city),
-            guildId,
-            userId,
-            id
+            this.pokemonId,
+            this.form,
+            this.minCP,
+            this.minIV,
+            JSON.stringify(this.ivList),
+            this.minLvl,
+            this.maxLvl,
+            this.gender,
+            JSON.stringify(this.city),
+            this.guildId,
+            this.userId,
+            this.id
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -73,7 +73,7 @@ class Pokemon {
                     result.min_lvl,
                     result.max_lvl,
                     result.gender,
-                    result.city
+                    JSON.parse(result.city || '[]'),
                 ));
             });
             return list;
@@ -81,13 +81,13 @@ class Pokemon {
         return null;
     }
 
-    static async getByPokemon(guildId, userId, pokemonId, form, city) {
+    static async getByPokemon(guildId, userId, pokemonId, form) {
         const sql = `
         SELECT id, subscription_id, guild_id, user_id, pokemon_id, form, min_cp, min_iv, iv_list, min_lvl, max_lvl, gender, city
         FROM pokemon
-        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ?
         `;
-        const args = [guildId, userId, pokemonId, form, city];
+        const args = [guildId, userId, pokemonId, form];
         const results = await db.query(sql, args);
         if (results && results.length > 0) {
             const result = results[0];
@@ -104,7 +104,7 @@ class Pokemon {
                 result.min_lvl,
                 result.max_lvl,
                 result.gender,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
@@ -133,7 +133,7 @@ class Pokemon {
                 result.min_lvl,
                 result.max_lvl,
                 result.gender,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
@@ -174,7 +174,7 @@ class Pokemon {
             minLvl,
             maxLvl,
             gender,
-            city,
+            JSON.stringify(city),
             guildId,
             userId,
             id
@@ -198,7 +198,7 @@ class Pokemon {
             ${this.minLvl},
             ${this.maxLvl},
             '${this.gender}',
-            ${this.city ? '"' + this.city + '"' : '""'}
+            '${JSON.stringify(this.city)}'
         )
         `;
     }

--- a/src/models/pvp.js
+++ b/src/models/pvp.js
@@ -64,7 +64,7 @@ class PVP {
                     result.league,
                     result.min_rank,
                     result.min_percent,
-                    result.city
+                    JSON.parse(result.city || '[]'),
                 ));
             });
             return list;
@@ -72,13 +72,13 @@ class PVP {
         return null;
     }
     
-    static async getPokemonByLeague(guildId, userId, pokemonId, form, league, city) {
+    static async getPokemonByLeague(guildId, userId, pokemonId, form, league) {
         const sql = `
         SELECT id, subscription_id, guild_id, user_id, pokemon_id, form, league, min_rank, min_percent, city
         FROM pvp
-        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND (form = ? OR form IS NULL) AND league = ? AND (city = ? OR city IS NULL)
+        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND (form = ? OR form IS NULL) AND league = ?
         `;
-        const args = [guildId, userId, pokemonId, form, league, city];
+        const args = [guildId, userId, pokemonId, form, league];
         const results = await db.query(sql, args);
         if (results && results.length > 0) {
             const result = results[0];
@@ -92,7 +92,7 @@ class PVP {
                 result.league,
                 result.min_rank,
                 result.min_percent,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
@@ -118,7 +118,7 @@ class PVP {
                 result.league,
                 result.min_rank,
                 result.min_percent,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
@@ -156,7 +156,7 @@ class PVP {
             league,
             minRank,
             minPercent,
-            city,
+            JSON.stringify(city),
             guildId,
             userId,
             id
@@ -177,7 +177,7 @@ class PVP {
             '${this.league}',
             ${this.minRank},
             ${this.minPercent},
-            ${this.city ? '"' + this.city + '"' : '""'}
+            '${JSON.stringify(this.city)}'
         )
         `;
     }

--- a/src/models/pvp.js
+++ b/src/models/pvp.js
@@ -5,7 +5,6 @@ const MySQLConnector = require('../services/mysql.js');
 const db = new MySQLConnector(config.db.brock);
 
 class PVP {
-
     constructor(id, subscriptionId, guildId, userId, pokemonId, form, league, minRank, minPercent, city) {
         this.id = id;
         this.subscriptionId = subscriptionId;
@@ -144,22 +143,22 @@ class PVP {
         return result.affectedRows > 0;
     }
 
-    static async save(id, guildId, userId, pokemonId, form, league, minRank, minPercent, city) {
+    async save() {
         const sql = `
         UPDATE pvp
         SET pokemon_id = ?, form = ?, league = ?, min_rank = ?, min_percent = ?, city = ?
         WHERE guild_id = ? AND user_id = ? AND id = ?
         `;
         const args = [
-            pokemonId,
-            form,
-            league,
-            minRank,
-            minPercent,
-            JSON.stringify(city),
-            guildId,
-            userId,
-            id
+            this.pokemonId,
+            this.form,
+            this.league,
+            this.minRank,
+            this.minPercent,
+            JSON.stringify(this.city),
+            this.guildId,
+            this.userId,
+            this.id,
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;

--- a/src/models/quest.js
+++ b/src/models/quest.js
@@ -20,7 +20,8 @@ class Quest {
         const args = [
             this.subscriptionId,
             this.guildId, this.userId,
-            this.reward, this.city
+            this.reward,
+            JSON.stringify(this.city || []),
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;
@@ -42,7 +43,7 @@ class Quest {
                     result.guild_id,
                     result.user_id,
                     result.reward,
-                    result.city
+                    JSON.parse(result.city || '[]'),
                 ));
             });
             return list;
@@ -65,20 +66,20 @@ class Quest {
                 result.guild_id,
                 result.user_id,
                 result.reward,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
     }
     
-    static async getByReward(guildId, userId, reward, city) {
+    static async getByReward(guildId, userId, reward) {
         const sql = `
         SELECT subscription_id, guild_id, user_id, reward, city
         FROM quests
-        WHERE guild_id = ? AND user_id = ? AND reward = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND reward = ?
         LIMIT 1
         `;
-        const args = [guildId, userId, reward, city];
+        const args = [guildId, userId, reward];
         const results = await db.query(sql, args);
         if (results && results.length > 0) {
             let result = results[0];
@@ -87,18 +88,18 @@ class Quest {
                 result.guild_id,
                 result.user_id,
                 result.reward,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
     }
 
-    static async delete(guildId, userId, reward, city) {
+    static async delete(guildId, userId, reward) {
         const sql = `
         DELETE FROM quests
-        WHERE guild_id = ? AND user_id = ? AND reward = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND reward = ?
         `;
-        const args = [guildId, userId, reward, city];
+        const args = [guildId, userId, reward];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;
     }
@@ -131,7 +132,7 @@ class Quest {
         `;
         const args = [
             reward,
-            city,
+            JSON.stringify(city),
             guildId,
             userId,
             id

--- a/src/models/quest.js
+++ b/src/models/quest.js
@@ -20,7 +20,8 @@ class Quest {
         `;
         const args = [
             this.subscriptionId,
-            this.guildId, this.userId,
+            this.guildId,
+            this.userId,
             this.reward,
             JSON.stringify(this.city || []),
         ];

--- a/src/models/quest.js
+++ b/src/models/quest.js
@@ -5,7 +5,8 @@ const MySQLConnector = require('../services/mysql.js');
 const db = new MySQLConnector(config.db.brock);
 
 class Quest {
-    constructor(subscriptionId, guildId, userId, reward, city) {
+    constructor(id, subscriptionId, guildId, userId, reward, city) {
+        this.id = id;
         this.subscriptionId = subscriptionId;
         this.guildId = guildId;
         this.userId = userId;
@@ -29,7 +30,7 @@ class Quest {
 
     static async getAll(guildId, userId) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, reward, city
+        SELECT id, subscription_id, guild_id, user_id, reward, city
         FROM quests
         WHERE guild_id = ? AND user_id = ?
         `;
@@ -39,6 +40,7 @@ class Quest {
             const list = [];
             results.forEach(result => {
                 list.push(new Quest(
+                    result.id,
                     result.subscription_id,
                     result.guild_id,
                     result.user_id,
@@ -53,7 +55,7 @@ class Quest {
 
     static async getById(id) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, reward, city
+        SELECT id, subscription_id, guild_id, user_id, reward, city
         FROM quests
         WHERE id = ?
         `;
@@ -62,6 +64,7 @@ class Quest {
         if (results && results.length > 0) {
             const result = results[0];
             return new Quest(
+                result.id,
                 result.subscription_id,
                 result.guild_id,
                 result.user_id,
@@ -74,7 +77,7 @@ class Quest {
     
     static async getByReward(guildId, userId, reward) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, reward, city
+        SELECT id, subscription_id, guild_id, user_id, reward, city
         FROM quests
         WHERE guild_id = ? AND user_id = ? AND reward = ?
         LIMIT 1
@@ -84,6 +87,7 @@ class Quest {
         if (results && results.length > 0) {
             let result = results[0];
             return new Quest(
+                result.id,
                 result.subscription_id,
                 result.guild_id,
                 result.user_id,
@@ -124,18 +128,18 @@ class Quest {
         return result.affectedRows > 0;
     }
 
-    static async save(id, guildId, userId, reward, city) {
+    async save() {
         const sql = `
         UPDATE quests
         SET reward = ?, city = ?
         WHERE guild_id = ? AND user_id = ? AND id = ?
         `;
         const args = [
-            reward,
-            JSON.stringify(city),
-            guildId,
-            userId,
-            id
+            this.reward,
+            JSON.stringify(this.city),
+            this.guildId,
+            this.userId,
+            this.id
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;

--- a/src/models/raid.js
+++ b/src/models/raid.js
@@ -4,7 +4,8 @@ const MySQLConnector = require('../services/mysql.js');
 const db = new MySQLConnector(config.db.brock);
 
 class Raid {
-    constructor(subscriptionId, guildId, userId, pokemonId, form, city) {
+    constructor(id, subscriptionId, guildId, userId, pokemonId, form, city) {
+        this.id = id;
         this.subscriptionId = subscriptionId;
         this.guildId = guildId;
         this.userId = userId;
@@ -36,7 +37,7 @@ class Raid {
 
     static async getAll(guildId, userId) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, pokemon_id, form, city
+        SELECT id, subscription_id, guild_id, user_id, pokemon_id, form, city
         FROM raids
         WHERE guild_id = ? AND user_id = ?
         `;
@@ -46,6 +47,7 @@ class Raid {
             const list = [];
             results.forEach(result => {
                 list.push(new Raid(
+                    result.id,
                     result.subscription_id,
                     result.guild_id,
                     result.user_id,
@@ -61,7 +63,7 @@ class Raid {
 
     static async getById(id) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, pokemon_id, form, city
+        SELECT id, subscription_id, guild_id, user_id, pokemon_id, form, city
         FROM raids
         WHERE id = ?
         `;
@@ -70,6 +72,7 @@ class Raid {
         if (results && results.length > 0) {
             const result = results[0];
             return new Raid(
+                result.id,
                 result.subscription_id,
                 result.guild_id,
                 result.user_id,
@@ -83,9 +86,9 @@ class Raid {
 
     static async getByPokemon(guildId, userId, pokemonId, form) {
         const sql = `
-        SELECT subscription_id, guild_id, user_id, pokemon_id, form, city
+        SELECT id, subscription_id, guild_id, user_id, pokemon_id, form, city
         FROM raids
-        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ?
+        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND (form = ? OR form IS NULL)
         LIMIT 1
         `;
         const args = [guildId, userId, pokemonId, form];
@@ -93,10 +96,11 @@ class Raid {
         if (results && results.length > 0) {
             let result = results[0];
             return new Raid(
+                result.id,
                 result.subscription_id,
                 result.guild_id,
                 result.user_id,
-                result.pokemonId,
+                result.pokemon_id,
                 result.form,
                 JSON.parse(result.city || '[]'),
             );
@@ -134,19 +138,19 @@ class Raid {
         return result.affectedRows > 0;
     }
 
-    static async save(id, guildId, userId, pokemonId, form, city) {
+    async save() {
         const sql = `
         UPDATE raids
         SET pokemon_id = ?, form = ?, city = ?
         WHERE guild_id = ? AND user_id = ? AND id = ?
         `;
         const args = [
-            pokemonId,
-            form,
-            JSON.stringify(city),
-            guildId,
-            userId,
-            id
+            this.pokemonId,
+            this.form,
+            JSON.stringify(this.city),
+            this.guildId,
+            this.userId,
+            this.id,
         ];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;
@@ -155,7 +159,7 @@ class Raid {
     toSql() {
         return `
         (
-            ${null},
+            ${this.id || 0},
             ${this.subscriptionId},
             ${this.guildId},
             ${this.userId},

--- a/src/models/raid.js
+++ b/src/models/raid.js
@@ -109,7 +109,7 @@ class Raid {
         DELETE FROM raids
         WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ?
         `;
-        const args = [guildId, userId, pokemonId, form, city];
+        const args = [guildId, userId, pokemonId, form];
         const result = await db.query(sql, args);
         return result.affectedRows === 1;
     }

--- a/src/models/raid.js
+++ b/src/models/raid.js
@@ -51,7 +51,7 @@ class Raid {
                     result.user_id,
                     result.pokemonId,
                     result.form,
-                    result.city
+                    JSON.parse(result.city || '[]'),
                 ));
             });
             return list;
@@ -75,20 +75,20 @@ class Raid {
                 result.user_id,
                 result.pokemon_id,
                 result.form,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
     }
 
-    static async getByPokemon(guildId, userId, pokemonId, form, city) {
+    static async getByPokemon(guildId, userId, pokemonId, form) {
         const sql = `
         SELECT subscription_id, guild_id, user_id, pokemon_id, form, city
         FROM raids
-        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ?
         LIMIT 1
         `;
-        const args = [guildId, userId, pokemonId, form, city];
+        const args = [guildId, userId, pokemonId, form];
         const results = await db.query(sql, args);
         if (results && results.length > 0) {
             let result = results[0];
@@ -98,16 +98,16 @@ class Raid {
                 result.user_id,
                 result.pokemonId,
                 result.form,
-                result.city
+                JSON.parse(result.city || '[]'),
             );
         }
         return null;
     }
 
-    static async delete(guildId, userId, pokemonId, form, city) {
+    static async delete(guildId, userId, pokemonId, form) {
         const sql = `
         DELETE FROM raids
-        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ? AND city = ?
+        WHERE guild_id = ? AND user_id = ? AND pokemon_id = ? AND form = ?
         `;
         const args = [guildId, userId, pokemonId, form, city];
         const result = await db.query(sql, args);
@@ -143,7 +143,7 @@ class Raid {
         const args = [
             pokemonId,
             form,
-            city,
+            JSON.stringify(city),
             guildId,
             userId,
             id
@@ -161,7 +161,7 @@ class Raid {
             ${this.userId},
             ${this.pokemonId},
             ${this.form ? '"' + this.form + '"' : '""'},
-            ${this.city ? '"' + this.city + '"' : '""'}
+            '${JSON.stringify(this.city)}'
         )
         `;
     }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -149,10 +149,9 @@ router.post('/pokemon/new', async (req, res) => {
         min_lvl,
         max_lvl,
         gender,
-        //city
+        city
     } = req.body;
     const user_id = defaultData.user_id;
-    /*
     let cities;
     if (city === 'all') {
         config.discord.guilds.map(x => {
@@ -165,45 +164,44 @@ router.post('/pokemon/new', async (req, res) => {
             cities = [city];
         }
     }
-    */
-    //if (cities) {
-    const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
-    const sql = [];
-    //for (let i = 0; i < cities.length; i++) {
-    const area = '';//cities[i];
-    const split = pokemon.split(',');
-    for (let i = 0; i < split.length; i++) {
-        const pokemonId = split[i];
-        let exists = await Pokemon.getByPokemon(guild_id, user_id, pokemonId, form, area);
-        if (exists) {
-            exists.minCP = 0;
-            exists.minIV = iv;
-            exists.ivList = iv_list ? iv_list.split('\n') : [];
-            exists.minLvl = min_lvl || 0;
-            exists.maxLvl = max_lvl || 35;
-            exists.gender = gender || '*';
-        } else {
-            exists = new Pokemon(
-                0,
-                subscriptionId,
-                guild_id,
-                user_id,
-                pokemonId,
-                form,
-                0,
-                isUltraRarePokemon(pokemonId) ? 0 : iv || 0,
-                iv_list ? iv_list.split('\n') : [],
-                min_lvl || 0,
-                max_lvl || 35,
-                gender || '*',
-                area || null
-            );
+    if (cities) {
+        const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
+        const sql = [];
+        for (let i = 0; i < cities.length; i++) {
+            const area = cities[i];
+            const split = pokemon.split(',');
+            for (let i = 0; i < split.length; i++) {
+                const pokemonId = split[i];
+                let exists = await Pokemon.getByPokemon(guild_id, user_id, pokemonId, form, area);
+                if (exists) {
+                    exists.minCP = 0;
+                    exists.minIV = iv;
+                    exists.ivList = iv_list ? iv_list.split('\n') : [];
+                    exists.minLvl = min_lvl || 0;
+                    exists.maxLvl = max_lvl || 35;
+                    exists.gender = gender || '*';
+                } else {
+                    exists = new Pokemon(
+                        0,
+                        subscriptionId,
+                        guild_id,
+                        user_id,
+                        pokemonId,
+                        form,
+                        0,
+                        isUltraRarePokemon(pokemonId) ? 0 : iv || 0,
+                        iv_list ? iv_list.split('\n') : [],
+                        min_lvl || 0,
+                        max_lvl || 35,
+                        gender || '*',
+                        area || null
+                    );
+                }
+                sql.push(exists.toSql());
+            }
         }
-        sql.push(exists.toSql());
+        await Pokemon.create(sql);
     }
-    //}
-    await Pokemon.create(sql);
-    //}
     res.redirect('/pokemon');
 });
 
@@ -286,7 +284,7 @@ router.post('/pvp/new', async (req, res) => {
         league,
         min_rank,
         min_percent,
-        //city
+        city
     } = req.body;
     const user_id = defaultData.user_id;
     const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
@@ -294,7 +292,6 @@ router.post('/pvp/new', async (req, res) => {
         console.error('Failed to get user subscription ID for GuildId:', guild_id, 'and UserId:', user_id);
         return;
     }
-    /*
     let cities;
     if (city === 'all') {
         config.discord.guilds.map(x => {
@@ -307,26 +304,25 @@ router.post('/pvp/new', async (req, res) => {
             cities = [city];
         }
     }
-    */
-    //if (cities) {
-    const sql = [];
-    //for (let i = 0; i < cities.length; i++) {
-    const area = '';//cities[i];
-    const split = pokemon.split(',');
-    for (let i = 0; i < split.length; i++) {
-        const pokemonId = split[i];
-        let exists = await PVP.getPokemonByLeague(guild_id, user_id, pokemonId, form, league, area);
-        if (exists) {
-            exists.minRank = min_rank;
-            exists.minPercent = min_percent;
-        } else {
-            exists = new PVP(0, subscriptionId, guild_id, user_id, pokemonId, form, league, min_rank || 25, min_percent || 98, area);
+    if (cities) {
+        const sql = [];
+        for (let i = 0; i < cities.length; i++) {
+            const area = cities[i];
+            const split = pokemon.split(',');
+            for (let i = 0; i < split.length; i++) {
+                const pokemonId = split[i];
+                let exists = await PVP.getPokemonByLeague(guild_id, user_id, pokemonId, form, league, area);
+                if (exists) {
+                    exists.minRank = min_rank;
+                    exists.minPercent = min_percent;
+                } else {
+                    exists = new PVP(0, subscriptionId, guild_id, user_id, pokemonId, form, league, min_rank || 25, min_percent || 98, area);
+                }
+                sql.push(exists.toSql());
+            }
         }
-        sql.push(exists.toSql());
+        await PVP.create(sql);
     }
-    //}
-    await PVP.create(sql);
-    //}
     res.redirect('/pokemon#pvp');
 });
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -170,7 +170,7 @@ router.post('/pokemon/new', async (req, res) => {
         if (exists) {
             exists.minCP = 0;
             exists.minIV = iv || 0;
-            exists.ivList = iv_list ? iv_list.split('\n') : [];
+            exists.ivList = iv_list ? iv_list.split('\r\n') : [];
             exists.minLvl = min_lvl || 0;
             exists.maxLvl = max_lvl || 35;
             exists.gender = gender || '*';
@@ -185,7 +185,7 @@ router.post('/pokemon/new', async (req, res) => {
                 form || null,
                 0,
                 isUltraRarePokemon(pokemonId) ? 0 : iv || 0,
-                iv_list ? iv_list.split('\n') : [],
+                iv_list ? iv_list.split('\r\n') : [],
                 min_lvl || 0,
                 max_lvl || 35,
                 gender || '*',
@@ -219,9 +219,8 @@ router.post('/pokemon/edit/:id', async (req, res) => {
         pkmn.form = form;
         pkmn.minCP = 0;
         // If pokemon is rare (Unown, Azelf, etc), set IV value to 0
-        //pkmn.minIV = isUltraRarePokemon(pokemon) ? 0 : iv || 0;
-        pkmn.minIV = iv || 0; // TODO: Check if Pokemon ultra rare
-        pkmn.ivList = iv_list ? iv_list.split('\n') : [];
+        pkmn.minIV = isUltraRarePokemon(pokemon) ? 0 : iv || 100;
+        pkmn.ivList = iv_list ? iv_list.split('\r\n') : [];
         pkmn.minLvl = min_lvl || 0;
         pkmn.maxLvl = max_lvl || 35;
         pkmn.gender = gender || '*';

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -152,7 +152,7 @@ router.post('/pokemon/new', async (req, res) => {
         city
     } = req.body;
     const user_id = defaultData.user_id;
-    const areas = getAreas(city);
+    const areas = getAreas(guild_id, city);
     const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
     const sql = [];
     const split = pokemon.split(',');
@@ -205,7 +205,7 @@ router.post('/pokemon/edit/:id', async (req, res) => {
     } = req.body;
     const user_id = defaultData.user_id;
     const pkmn = await Pokemon.getById(id);
-    const areas = getAreas(city);
+    const areas = getAreas(guild_id, city);
     if (pkmn) {
         const result = await Pokemon.save(
             id,
@@ -278,7 +278,7 @@ router.post('/pvp/new', async (req, res) => {
         console.error('Failed to get user subscription ID for GuildId:', guild_id, 'and UserId:', user_id);
         return;
     }
-    const areas = getAreas(city);
+    const areas = getAreas(guild_id, city);
     const sql = [];
     const split = pokemon.split(',');
     for (let i = 0; i < split.length; i++) {
@@ -311,7 +311,7 @@ router.post('/pvp/edit/:id', async (req, res) => {
     const user_id = defaultData.user_id;
     const exists = await PVP.getById(id);
     if (exists) {
-        const areas = getAreas(city);
+        const areas = getAreas(guild_id, city);
         const result = await PVP.save(id, guild_id, user_id, pokemon, form, league, min_rank || 25, min_percent || 98, areas);
         if (result) {
             // Success
@@ -357,7 +357,7 @@ router.post('/raids/new', async (req, res) => {
     const { guild_id, pokemon, form, city } = req.body;
     const user_id = defaultData.user_id;
     const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
-    const areas = getAreas(city);
+    const areas = getAreas(guild_id, city);
     let sql = [];
     const split = pokemon.split(',');
     for (let i = 0; i < split.length; i++) {
@@ -378,7 +378,7 @@ router.post('/raids/edit/:id', async (req, res) => {
     const user_id = defaultData.user_id;
     const exists = await Raid.getByPokemon(guild_id, user_id, pokemon, form);
     if (exists) {
-        const areas = getAreas(city);
+        const areas = getAreas(guild_id, city);
         const result = await Raid.save(id, guild_id, user_id, pokemon, form, areas);
         if (result) {
             // Success
@@ -474,7 +474,7 @@ router.post('/quests/new', async (req, res) => {
     const { guild_id, reward, city } = req.body;
     const user_id = defaultData.user_id;
     const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
-    const areas = getAreas(city);
+    const areas = getAreas(guild_id, city);
     const exists = await Quest.getByReward(guild_id, user_id, reward);
     if (exists) {
         // Already exists
@@ -496,7 +496,7 @@ router.post('/quests/edit/:id', async (req, res) => {
     const user_id = defaultData.user_id;
     const quest = await Quest.getById(id);
     if (quest) {
-        const areas = getAreas(city);
+        const areas = getAreas(guild_id, city);
         const result = await Quest.save(id, guild_id, user_id, reward, areas);
         if (result) {
             // Success
@@ -542,7 +542,7 @@ router.post('/invasions/new', async (req, res) => {
     const { guild_id, pokemon, city } = req.body;
     const user_id = defaultData.user_id;
     const subscriptionId = await subscriptions.getUserSubscriptionId(guild_id, user_id);
-    const areas = getAreas(city);
+    const areas = getAreas(guild_id, city);
     const split = pokemon.split(',');
     for (let i = 0; i < split.length; i++) {
         const pokemonId = split[i];
@@ -569,7 +569,7 @@ router.post('/invasions/edit/:id', async (req, res) => {
     const user_id = defaultData.user_id;
     const invasion = await Invasion.getById(id);
     if (invasion) {
-        const areas = getAreas(city);
+        const areas = getAreas(guild_id, city);
         const result = await Invasion.save(id, guild_id, user_id, reward, areas);
         if (result) {
             // Success
@@ -650,11 +650,11 @@ const isUltraRarePokemon = (pokemonId) => {
     return ultraRareList.includes(pokemonId);
 };
 
-const getAreas = (city) => {
+const getAreas = (guildId, city) => {
     let areas;
     if (city === 'all') {
         config.discord.guilds.map(x => {
-            if (x.id === guild_id) {
+            if (x.id === guildId) {
                 areas = x.geofences;
             }
         });

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -479,7 +479,7 @@ router.post('/gyms/new', async (req, res) => {
             console.error('Failed to create Gym subscription', name);
         }
     }
-    res.redirect('/raids');
+    res.redirect('/raids#gyms');
 });
 
 router.post('/gyms/delete/:id', async (req, res) => {

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -12,6 +12,7 @@ const Raid = require('../models/raid.js');
 const Gym = require('../models/gym.js');
 const Quest = require('../models/quest.js');
 const Invasion = require('../models/invasion.js');
+const Localizer = require('../services/locale.js');
 const utils = require('../services/utils.js');
 
 /* eslint-disable no-case-declarations */
@@ -36,10 +37,11 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
         case 'pokemon':
             const pokemon = await subscriptions.getPokemonSubscriptions(guild_id, user_id);
             if (pokemon) {
-                pokemon.forEach(pkmn => {
-                    pkmn.name = `<img src='${utils.getPokemonIcon(pkmn.pokemon_id, pkmn.form)}' width='auto' height='32'>&nbsp;${pkmn.name}`;
+                for (let pkmn of pokemon) {
+                    const pkmnIcon = await Localizer.instance.getPokemonIcon(pkmn.pokemon_id);
+                    pkmn.name = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${pkmn.name}`;
                     pkmn.iv_list = (pkmn.iv_list || []).length;
-                    pkmn.gender == '*'
+                    pkmn.gender = pkmn.gender === '*'
                         ? 'All'
                         : pkmn.gender == 'm'
                             ? 'Male Only'
@@ -51,77 +53,80 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
                     &nbsp;
                     <a href='/pokemon/delete/${pkmn.id}'><button type='button'class='btn btn-sm btn-danger'>Delete</button></a>
                     `;
-                });
+                }
             }
             res.json({ data: { pokemon: pokemon } });
             break;
         case 'pvp':
             const pvp = await subscriptions.getPvpSubscriptions(guild_id, user_id);
             if (pvp) {
-                pvp.forEach(pvpSub => {
-                    pvpSub.name = `<img src='${utils.getPokemonIcon(pvpSub.pokemon_id, pvpSub.form)}' width='auto' height='32'>&nbsp;${pvpSub.name}`;
+                for (let pvpSub of pvp) {
+                    const pkmnIcon = await Localizer.instance.getPokemonIcon(pvpSub.pokemon_id);
+                    pvpSub.name = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${pvpSub.name}`;
                     pvpSub.city = formatAreas(guild_id, pvpSub.city);
                     pvpSub.buttons = `
                     <a href='/pvp/edit/${pvpSub.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
                     <a href='/pvp/delete/${pvpSub.id}'><button type='button'class='btn btn-sm btn-danger'>Delete</button></a>
                     `;
-                });
+                }
             }
             res.json({ data: { pvp: pvp } });
             break;
         case 'raids':
             const raids = await subscriptions.getRaidSubscriptions(guild_id, user_id);
             if (raids) {
-                raids.forEach(raid => {
-                    raid.name = `<img src='${utils.getPokemonIcon(raid.pokemon_id, raid.form)}' width='auto' height='32'>&nbsp;${raid.name}`;
+                for (let raid of raids) {
+                    const pkmnIcon = await Localizer.instance.getPokemonIcon(raid.pokemon_id);
+                    raid.name = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${raid.name}`;
                     raid.city = formatAreas(guild_id, raid.city);
                     raid.buttons = `
                     <a href='/raid/edit/${raid.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
                     <a href='/raid/delete/${raid.id}'><button type='button'class='btn btn-sm btn-danger'>Delete</button></a>
                     `;
-                });
+                }
             }
             res.json({ data: { raids: raids } });
             break;
         case 'gyms':
             const gyms = await subscriptions.getGymSubscriptions(guild_id, user_id);
             if (gyms) {
-                gyms.forEach(gym => {
+                for (let gym of gyms) {
                     gym.buttons = `
                     <a href='/gym/delete/${gym.id}'><button type='button'class='btn btn-sm btn-danger'>Delete</button></a>
                     `;
-                });
+                }
             }
             res.json({ data: { gyms: gyms } });
             break;
         case 'quests':
             const quests = await subscriptions.getQuestSubscriptions(guild_id, user_id);
             if (quests) {
-                quests.forEach(quest => {
+                for (let quest of quests) {
                     quest.city = formatAreas(guild_id, quest.city);
                     quest.buttons = `
                     <a href='/quest/edit/${quest.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
                     <a href='/quest/delete/${quest.id}'><button type='button'class='btn btn-sm btn-danger'>Delete</button></a>
                     `;
-                });
+                }
             }
             res.json({ data: { quests: quests } });
             break;
         case 'invasions':
             const invasions = await subscriptions.getInvasionSubscriptions(guild_id, user_id);
             if (invasions) {
-                invasions.forEach(invasion => {
-                    invasion.reward = `<img src='${utils.getPokemonIcon(invasion.reward_pokemon_id, 0)}' width='auto' height='32'>&nbsp;${invasion.reward}`;
+                for (let invasion of invasions) {
+                    const pkmnIcon = await Localizer.instance.getPokemonIcon(invasion.reward_pokemon_id);
+                    invasion.reward = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${invasion.reward}`;
                     invasion.city = formatAreas(guild_id, invasion.city);
                     invasion.buttons = `
                     <a href='/invasion/edit/${invasion.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
                     <a href='/invasion/delete/${invasion.id}'><button type='button'class='btn btn-sm btn-danger'>Delete</button></a>
                     `;
-                });
+                }
             }
             res.json({ data: { invasions: invasions } });
             break;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -38,7 +38,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             const pokemon = await subscriptions.getPokemonSubscriptions(guild_id, user_id);
             if (pokemon) {
                 for (let pkmn of pokemon) {
-                    const pkmnIcon = await Localizer.instance.getPokemonIcon(pkmn.pokemon_id);
+                    const pkmnIcon = await Localizer.getPokemonIcon(pkmn.pokemon_id);
                     pkmn.name = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${pkmn.name}`;
                     pkmn.iv_list = (pkmn.iv_list || []).length;
                     pkmn.gender = pkmn.gender === '*'
@@ -61,7 +61,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             const pvp = await subscriptions.getPvpSubscriptions(guild_id, user_id);
             if (pvp) {
                 for (let pvpSub of pvp) {
-                    const pkmnIcon = await Localizer.instance.getPokemonIcon(pvpSub.pokemon_id);
+                    const pkmnIcon = await Localizer.getPokemonIcon(pvpSub.pokemon_id);
                     pvpSub.name = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${pvpSub.name}`;
                     pvpSub.city = formatAreas(guild_id, pvpSub.city);
                     pvpSub.buttons = `
@@ -77,7 +77,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             const raids = await subscriptions.getRaidSubscriptions(guild_id, user_id);
             if (raids) {
                 for (let raid of raids) {
-                    const pkmnIcon = await Localizer.instance.getPokemonIcon(raid.pokemon_id);
+                    const pkmnIcon = await Localizer.getPokemonIcon(raid.pokemon_id);
                     raid.name = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${raid.name}`;
                     raid.city = formatAreas(guild_id, raid.city);
                     raid.buttons = `
@@ -118,7 +118,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             const invasions = await subscriptions.getInvasionSubscriptions(guild_id, user_id);
             if (invasions) {
                 for (let invasion of invasions) {
-                    const pkmnIcon = await Localizer.instance.getPokemonIcon(invasion.reward_pokemon_id);
+                    const pkmnIcon = await Localizer.getPokemonIcon(invasion.reward_pokemon_id);
                     invasion.reward = `<img src='${pkmnIcon}' width='auto' height='32'>&nbsp;${invasion.reward}`;
                     invasion.city = formatAreas(guild_id, invasion.city);
                     invasion.buttons = `

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -219,7 +219,7 @@ router.post('/pokemon/edit/:id', async (req, res) => {
         pkmn.form = form;
         pkmn.minCP = 0;
         // If pokemon is rare (Unown, Azelf, etc), set IV value to 0
-        pkmn.minIV = isUltraRarePokemon(pokemon) ? 0 : iv || 100;
+        pkmn.minIV = isUltraRarePokemon(pkmn) ? 0 : iv || 100;
         pkmn.ivList = iv_list ? iv_list.split('\r\n') : [];
         pkmn.minLvl = min_lvl || 0;
         pkmn.maxLvl = max_lvl || 35;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -13,6 +13,7 @@ const Gym = require('../models/gym.js');
 const Quest = require('../models/quest.js');
 const Invasion = require('../models/invasion.js');
 const utils = require('../services/utils.js');
+const { locale } = require('../data/default.js');
 
 /* eslint-disable no-case-declarations */
 router.post('/server/:guild_id/user/:user_id', async (req, res) => {
@@ -45,6 +46,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
                             ? 'Male Only'
                             : 'Female Only';
                     pkmn.gender_name = pkmn.gender === '*' ? 'All' : pkmn.gender;
+                    pkmn.city = formatAreas(guild_id, pkmn.city);
                     pkmn.buttons = `
                     <a href='/pokemon/edit/${pkmn.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
@@ -59,6 +61,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             if (pvp) {
                 pvp.forEach(pvpSub => {
                     pvpSub.name = `<img src='${utils.getPokemonIcon(pvpSub.pokemon_id, pvpSub.form)}' width='auto' height='32'>&nbsp;${pvpSub.name}`;
+                    pvpSub.city = formatAreas(guild_id, pvpSub.city);
                     pvpSub.buttons = `
                     <a href='/pvp/edit/${pvpSub.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
@@ -73,6 +76,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             if (raids) {
                 raids.forEach(raid => {
                     raid.name = `<img src='${utils.getPokemonIcon(raid.pokemon_id, raid.form)}' width='auto' height='32'>&nbsp;${raid.name}`;
+                    raid.city = formatAreas(guild_id, raid.city);
                     raid.buttons = `
                     <a href='/raid/edit/${raid.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
@@ -97,6 +101,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             const quests = await subscriptions.getQuestSubscriptions(guild_id, user_id);
             if (quests) {
                 quests.forEach(quest => {
+                    quest.city = formatAreas(guild_id, quest.city);
                     quest.buttons = `
                     <a href='/quest/edit/${quest.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
@@ -111,6 +116,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             if (invasions) {
                 invasions.forEach(invasion => {
                     invasion.reward = `<img src='${utils.getPokemonIcon(invasion.reward_pokemon_id, 0)}' width='auto' height='32'>&nbsp;${invasion.reward}`;
+                    invasion.city = formatAreas(guild_id, invasion.city);
                     invasion.buttons = `
                     <a href='/invasion/edit/${invasion.id}'><button type='button'class='btn btn-sm btn-primary'>Edit</button></a>
                     &nbsp;
@@ -664,6 +670,12 @@ const getAreas = (guildId, city) => {
         }
     }
     return areas;
+};
+
+const formatAreas = (guildId, subscriptionAreas) => {
+    return utils.arraysEqual(subscriptionAreas, config.discord.guilds.filter(x => x.id === guildId)[0].geofences)
+        ? 'All' // TODO: Localize
+        : subscriptionAreas.join(',');
 };
 
 module.exports = router;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -13,7 +13,6 @@ const Gym = require('../models/gym.js');
 const Quest = require('../models/quest.js');
 const Invasion = require('../models/invasion.js');
 const utils = require('../services/utils.js');
-const { locale } = require('../data/default.js');
 
 /* eslint-disable no-case-declarations */
 router.post('/server/:guild_id/user/:user_id', async (req, res) => {
@@ -405,7 +404,7 @@ router.post('/raids/new', async (req, res) => {
 
 router.post('/raids/edit/:id', async (req, res) => {
     const id = req.params.id;
-    const { guild_id, pokemon, form, city } = req.body;
+    const { guild_id, /*pokemon,*/ form, city } = req.body;
     //const user_id = defaultData.user_id;
     const exists = await Raid.getById(id);
     if (exists) {
@@ -551,7 +550,7 @@ router.post('/quests/new', async (req, res) => {
 
 router.post('/quests/edit/:id', async (req, res) => {
     const id = req.params.id;
-    const { guild_id, reward, city } = req.body;
+    const { guild_id, /*reward,*/ city } = req.body;
     //const user_id = defaultData.user_id;
     const quest = await Quest.getById(id);
     if (quest) {
@@ -640,7 +639,7 @@ router.post('/invasions/new', async (req, res) => {
 
 router.post('/invasions/edit/:id', async (req, res) => {
     const id = req.params.id;
-    const { guild_id, reward, city } = req.body;
+    const { guild_id, /*reward,*/ city } = req.body;
     //const user_id = defaultData.user_id;
     const invasion = await Invasion.getById(id);
     if (invasion) {

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -219,7 +219,7 @@ router.post('/pokemon/edit/:id', async (req, res) => {
         pkmn.form = form;
         pkmn.minCP = 0;
         // If pokemon is rare (Unown, Azelf, etc), set IV value to 0
-        pkmn.minIV = isUltraRarePokemon(pkmn) ? 0 : iv || 100;
+        pkmn.minIV = isUltraRarePokemon(pkmn.pokemonId) ? 0 : iv || 100;
         pkmn.ivList = iv_list ? iv_list.split('\r\n') : [];
         pkmn.minLvl = min_lvl || 0;
         pkmn.maxLvl = max_lvl || 35;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -536,7 +536,7 @@ router.post('/quests/new', async (req, res) => {
         exists.city = utils.arrayUnique(exists.city.concat(areas || []));
         result = await exists.save();
     } else {
-        exists = new Quest(subscriptionId, guild_id, user_id, reward, areas);
+        exists = new Quest(0, subscriptionId, guild_id, user_id, reward, areas);
         result = await exists.create();
     }
     if (result) {

--- a/src/routes/discord.js
+++ b/src/routes/discord.js
@@ -35,17 +35,17 @@ router.get('/callback', catchAsyncErrors(async (req, res) => {
     axios.post('https://discord.com/api/oauth2/token', data, {
         headers: headers
     }).then(async (response) => {
-        //const client = new DiscordClient(response.data.access_token);
-        DiscordClient.setAccessToken(response.data.access_token);
-        const user = await DiscordClient.getUser();
-        const guilds = await DiscordClient.getGuilds();
+        const client = new DiscordClient(response.data.access_token);
+        client.setAccessToken(response.data.access_token);
+        const user = await client.getUser();
+        const guilds = await client.getGuilds();
         if (config.discord.userIdWhitelist.length > 0 && config.discord.userIdWhitelist.includes(user.id)) {
             console.log(`Discord user ${user.id} in whitelist, skipping role and guild check...`);
             req.session.logged_in = true;
             req.session.user_id = user.id;
             req.session.username = `${user.username}#${user.discriminator}`;
             req.session.guilds = guilds;
-            req.session.roles = await buildGuildRoles(DiscordClient, user.id, guilds);
+            req.session.roles = await buildGuildRoles(client, user.id, guilds);
             req.session.valid = true;
             req.session.save();
             res.redirect(`/?token=${response.data.access_token}`);
@@ -56,7 +56,7 @@ router.get('/callback', catchAsyncErrors(async (req, res) => {
         req.session.user_id = user.id;
         req.session.username = `${user.username}#${user.discriminator}`;
         req.session.guilds = guilds;
-        req.session.roles = await buildGuildRoles(DiscordClient, user.id, guilds);
+        req.session.roles = await buildGuildRoles(client, user.id, guilds);
         req.session.valid = utils.hasGuild(guilds);
         req.session.save();
         if (req.session.valid) {

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -256,7 +256,7 @@ router.get('/invasions', (req, res) => {
 router.get('/invasion/new', (req, res) => {
     const data = defaultData;
     data.servers = validateRoles(req, res);
-    data.rewards = map.getGruntRewardIdsList();
+    data.rewards = map.getPokemonNameIdsList();
     data.cities = map.buildCityList(req.session.guilds);
     res.render('invasion-new', data);
 });
@@ -267,9 +267,9 @@ router.get('/invasion/edit/:id', async (req, res) => {
     const id = req.params.id;
     data.id = id;
     const invasion = await Invasion.getById(id);
-    data.rewards = map.getGruntRewardIdsList();
+    data.rewards = map.getPokemonNameIdsList();
     data.rewards.forEach(reward => {
-        reward.selected = reward.pokemon_id === invasion.rewardPokemonId;
+        reward.selected = reward.id === invasion.rewardPokemonId;
     });
     data.cities = map.buildCityList(req.session.guilds);
     const areas = invasion.city.map(x => x.toLowerCase());

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -305,7 +305,7 @@ const validateRoles = (req, res) => {
     const guilds = req.session.guilds;
     const roles = req.session.roles;
     let valid = false;
-    servers.forEach(server => {
+    for (let server of servers) {
         if (roles[server.id]) {
             const userRoles = roles[server.id];
             const requiredRoles = config.discord.guilds.filter(x => x.id === server.id);
@@ -320,12 +320,12 @@ const validateRoles = (req, res) => {
         } else {
             server.show = false;
         }
-        if (!valid) {
-            console.error('Access not granted...');
-            res.redirect('/login');
-            return null;
-        }
-    });
+    }
+    if (!valid) {
+        console.error('Access not granted...');
+        res.redirect('/login');
+        return null;
+    }
     return servers;
 };
 

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -42,10 +42,10 @@ router.get('/pokemon', (req, res) => {
     res.render('pokemon', data);
 });
 
-router.get('/pokemon/new', (req, res) => {
+router.get('/pokemon/new', async (req, res) => {
     const data = defaultData;
     data.servers = validateRoles(req, res);
-    data.pokemon = map.getPokemonNameIdsList();
+    data.pokemon = await map.getPokemonNameIdsList();
     data.cities = map.buildCityList(req.session.guilds);
     res.render('pokemon-new', data);
 });
@@ -56,7 +56,7 @@ router.get('/pokemon/edit/:id', async (req, res) => {
     const id = req.params.id;
     data.id = id;
     const pokemon = await Pokemon.getById(id);
-    data.pokemon = map.getPokemonNameIdsList();
+    data.pokemon = await map.getPokemonNameIdsList();
     data.pokemon.forEach(pkmn => {
         pkmn.selected = parseInt(pkmn.id) === pokemon.pokemonId;
     });
@@ -90,10 +90,10 @@ router.get('/pokemon/delete_all', (req, res) => {
 
 
 // PVP routes
-router.get('/pvp/new', (req, res) => {
+router.get('/pvp/new', async (req, res) => {
     const data = defaultData;
     data.servers = validateRoles(req, res);
-    data.pokemon = map.getPokemonNameIdsList();
+    data.pokemon = await map.getPokemonNameIdsList();
     data.cities = map.buildCityList(req.session.guilds);
     res.render('pvp-new', data);
 });
@@ -104,7 +104,7 @@ router.get('/pvp/edit/:id', async (req, res) => {
     const id = req.params.id;
     data.id = id;
     const pvp = await PVP.getById(id);
-    data.pokemon = map.getPokemonNameIdsList();
+    data.pokemon = await map.getPokemonNameIdsList();
     data.pokemon.forEach(pkmn => {
         pkmn.selected = parseInt(pkmn.id) === pvp.pokemonId;
     });
@@ -142,10 +142,10 @@ router.get('/raids', (req, res) => {
     res.render('raids', data);
 });
 
-router.get('/raid/new', (req, res) => {
+router.get('/raid/new', async (req, res) => {
     const data = defaultData;
     data.servers = validateRoles(req, res);
-    data.pokemon = map.getPokemonNameIdsList();
+    data.pokemon = await map.getPokemonNameIdsList();
     data.cities = map.buildCityList(req.session.guilds);
     res.render('raid-new', data);
 });
@@ -156,7 +156,7 @@ router.get('/raid/edit/:id', async (req, res) => {
     const id = req.params.id;
     data.id = id;
     const raid = await Raid.getById(id);
-    data.pokemon = map.getPokemonNameIdsList();
+    data.pokemon = await map.getPokemonNameIdsList();
     data.pokemon.forEach(pkmn => {
         pkmn.selected = parseInt(pkmn.id) === raid.pokemonId;
     });
@@ -253,10 +253,10 @@ router.get('/invasions', (req, res) => {
     res.render('invasions', data);
 });
 
-router.get('/invasion/new', (req, res) => {
+router.get('/invasion/new', async (req, res) => {
     const data = defaultData;
     data.servers = validateRoles(req, res);
-    data.rewards = map.getPokemonNameIdsList();
+    data.rewards = await map.getPokemonNameIdsList();
     data.cities = map.buildCityList(req.session.guilds);
     res.render('invasion-new', data);
 });
@@ -267,7 +267,7 @@ router.get('/invasion/edit/:id', async (req, res) => {
     const id = req.params.id;
     data.id = id;
     const invasion = await Invasion.getById(id);
-    data.rewards = map.getPokemonNameIdsList();
+    data.rewards = await map.getPokemonNameIdsList();
     data.rewards.forEach(reward => {
         reward.selected = reward.id === invasion.rewardPokemonId;
     });

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -68,8 +68,9 @@ router.get('/pokemon/edit/:id', async (req, res) => {
         data.selected = gender.id === pokemon.gender;
     });
     data.cities = map.buildCityList(req.session.guilds);
+    const areas = pokemon.city.map(x => x.toLowerCase());
     data.cities.forEach(city => {
-        city.selected = city.name === pokemon.city;
+        city.selected = areas.includes(city.name.toLowerCase());
     });
     res.render('pokemon-edit', data);
 });
@@ -113,8 +114,9 @@ router.get('/pvp/edit/:id', async (req, res) => {
     data.min_rank = pvp.minRank;
     data.min_percent = pvp.minPercent;
     data.cities = map.buildCityList(req.session.guilds);
+    const areas = pvp.city.map(x => x.toLowerCase());
     data.cities.forEach(city => {
-        city.selected = city.name === pvp.city;
+        city.selected = areas.includes(city.name.toLowerCase());
     });
     res.render('pvp-edit', data);
 });
@@ -159,8 +161,9 @@ router.get('/raid/edit/:id', async (req, res) => {
         pkmn.selected = parseInt(pkmn.id) === raid.pokemonId;
     });
     data.cities = map.buildCityList(req.session.guilds);
+    const areas = raid.city.map(x => x.toLowerCase());
     data.cities.forEach(city => {
-        city.selected = city.name === raid.city;
+        city.selected = areas.includes(city.name.toLowerCase());
     });
     res.render('raid-edit', data);
 });
@@ -223,8 +226,9 @@ router.get('/quest/edit/:id', async (req, res) => {
     const quest = await Quest.getById(id);
     data.reward = quest.reward;
     data.cities = map.buildCityList(req.session.guilds);
+    const areas = quest.city.map(x => x.toLowerCase());
     data.cities.forEach(city => {
-        city.selected = city.name === quest.city;
+        city.selected = areas.includes(city.name.toLowerCase());
     });
     res.render('quest-edit', data);
 });
@@ -269,8 +273,9 @@ router.get('/invasion/edit/:id', async (req, res) => {
         reward.selected = reward.pokemon_id === invasion.rewardPokemonId;
     });
     data.cities = map.buildCityList(req.session.guilds);
+    const areas = invasion.city.map(x => x.toLowerCase());
     data.cities.forEach(city => {
-        city.selected = city.name === invasion.city;
+        city.selected = areas.includes(city.name.toLowerCase());
     });
     res.render('invasion-edit', data);
 });

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -186,7 +186,6 @@ router.get('/raids/delete_all', (req, res) => {
 router.get('/gym/new', (req, res) => {
     const data = defaultData;
     data.servers = validateRoles(req, res);
-    //data.cities = map.buildCityList(req.session.guilds);
     res.render('gym-new', data);
 });
 

--- a/src/services/discord.js
+++ b/src/services/discord.js
@@ -13,17 +13,9 @@ client.on('ready', () => {
     console.log(`Logged in as ${client.user.tag}!`);
 });
   
-client.on('message', (msg) => {
-    if (msg.content === 'ping') {
-        msg.reply('pong');
-    }
-});
-  
 client.login(config.discord.botToken);
 
 class DiscordClient {
-    //static instance = new DiscordClient();
-
     constructor(accessToken) {
         this.accessToken = accessToken;
     }
@@ -60,4 +52,4 @@ class DiscordClient {
     }
 }
 
-module.exports = new DiscordClient();
+module.exports = DiscordClient;

--- a/src/services/geofence.js
+++ b/src/services/geofence.js
@@ -150,36 +150,6 @@ const isLatLngInZone = (geofence, lat, lng) => {
     return polygonContainsPoint;
 };
 
-/*
-function checkcheck(x, y, cornersX, cornersY) {
-    var i, j=cornersX.length-1 ;
-    var odd = false;
-    var pX = cornersX;
-    var pY = cornersY;
-    for (i=0; i<cornersX.length; i++) {
-        if ((pY[i]< y && pY[j]>=y ||  pY[j]< y && pY[i]>=y)
-            && (pX[i]<=x || pX[j]<=x)) {
-              odd ^= (pX[i] + (y-pY[i])*(pX[j]-pX[i])/(pY[j]-pY[i])) < x; 
-        }
-        j=i; 
-    }
-    return odd;
-}
-
-function matchPointAndPolygon(point,polygon) {
-    const bbox = poly => poly.reduce((b,[x,y]) =>
-     ({"miX":Math.min(x,b.miX),"maX":Math.max(x,b.maX),"miY":Math.min(y,b.miY),"maY":Math.max(y,b.maY)}),
-     {"miX":poly[0][0],"maX":poly[0][0], "miY":poly[0][1],"maY":poly[0][1]});
-    const inBBox = ([x,y], box) => !(x < box.miX || x > box.maX || y < box.miY || y > box.maY);
-    const intersect = (xi,yi, xj,yj, u,v) =>
-     ((yi > v) != (yj > v)) && (u < (xj - xi) * (v - yi) / (yj - yi) + xi);
-    const nex = (i,t) => i===0? t.length-1 : i-1;
-    const insideWN = ([x,y], vs) => !!(vs.reduce((s,p,i,t) =>
-      s + intersect(p[0],p[1], t[nex(i,t)][0],t[nex(i,t)][1], x,y), 0));
-    return inBBox(point, bbox(polygon)) && insideWN(point, polygon);
-}
-*/
-
 module.exports = {
     Geofence,
     GeofenceService

--- a/src/services/locale.js
+++ b/src/services/locale.js
@@ -17,7 +17,7 @@ i18n.configure({
 i18n.setLocale('en');
 
 class Localizer {
-    static instance = new Localizer();
+    //static instance = new Localizer();
 
     constructor() {
         this.availablePokemon = (async () => {
@@ -82,4 +82,4 @@ class Localizer {
     }
 }
 
-module.exports = Localizer;
+module.exports = new Localizer();

--- a/src/services/locale.js
+++ b/src/services/locale.js
@@ -1,11 +1,85 @@
 'use strict';
 
+const axios = require('axios');
+const fs = require('fs');
 const i18n = require('i18n');
+const path = require('path');
+const util = require('util');
 
-const getPokemonName = (pokemonId) => {
-    return i18n.__('poke_' + pokemonId);
-};
+const config = require('../config.json');
 
-module.exports = {
-    getPokemonName
-};
+i18n.configure({
+    autoReload: true,
+    directory: path.resolve(__dirname, '../../static/locales'),
+    defaultLocale: 'en',
+    locales: ['en', 'de', 'es'],          
+});
+i18n.setLocale('en');
+
+class Localizer {
+    static instance = new Localizer();
+
+    constructor() {
+        this.availablePokemon = (async () => {
+            if (config.urls.images.pokemon.includes('http')) {
+                // Remote repo
+                const response = await axios.get(config.urls.images.pokemon + '/index.json');
+                return new Set(response.data);
+            } else {
+                // Locale repo
+                const pokemonIconsDir = path.resolve(__dirname, '../../static/' + config.urls.images.pokemon);
+                const files = await fs.promises.readdir(pokemonIconsDir);
+                if (files) {
+                    const availableForms = [];
+                    files.forEach(file => {
+                        const match = /^(.+)\.png$/.exec(file);
+                        if (match !== null) {
+                            availableForms.push(match[1]);
+                        }
+                    });
+                    return new Set(availableForms);
+                }
+            }
+        })();
+    }
+
+    getPokemonName(pokemonId) {
+        return i18n.__('poke_' + pokemonId);
+    }
+
+    /* eslint-enable no-unused-vars */
+    async getPokemonIcon(pokemonId, form = 0, evolution = 0, gender = 0, costume = 0, shiny = false) {
+        return `${config.urls.images.pokemon}/${await this.resolvePokemonIcon(pokemonId, form, evolution, gender, costume, shiny)}.png`;
+    }
+
+    async getRaidIcon(pokemonId, raidLevel, form, evolution, gender, costume) {
+        if (pokemonId > 0) {
+            return await this.getPokemonIcon(pokemonId, form, evolution, gender, costume);
+        }
+        return util.format(config.urls.images.eggs, raidLevel);
+    }
+
+    async resolvePokemonIcon(pokemonId, form = 0, evolution = 0, gender = 0, costume = 0, shiny = false) {
+        const evolutionSuffixes = evolution ? ['-e' + evolution, ''] : [''];
+        const formSuffixes = form ? ['-f' + form, ''] : [''];
+        const costumeSuffixes = costume ? ['-c' + costume, ''] : [''];
+        const genderSuffixes = gender ? ['-g' + gender, ''] : [''];
+        const shinySuffixes = shiny ? ['-shiny', ''] : [''];
+        const lookup = await this.availablePokemon;
+        for (const evolutionSuffix of evolutionSuffixes) {
+            for (const formSuffix of formSuffixes) {
+                for (const costumeSuffix of costumeSuffixes) {
+                    for (const genderSuffix of genderSuffixes) {
+                        for (const shinySuffix of shinySuffixes) {
+                            const result = `${pokemonId}${evolutionSuffix}${formSuffix}${costumeSuffix}${genderSuffix}${shinySuffix}`;
+                            if (lookup.has(result)) return result;
+                        }
+                    }
+                }
+            }
+        }
+        return '0'; // substitute
+    }
+}
+
+module.exports = Localizer;

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -95,6 +95,18 @@ const arraysEqual = (array1, array2) => {
     return true;
 };
 
+function arrayUnique(array) {
+    var newArray = array.concat();
+    for (let i = 0; i < newArray.length; i++) {
+        for (let j = i + 1; j < newArray.length; j++) {
+            if (newArray[i] === newArray[j]) {
+                newArray.splice(j--, 1);
+            }
+        }
+    }
+    return newArray;
+};
+
 module.exports = {
     generateString,
     hasGuild,
@@ -103,5 +115,6 @@ module.exports = {
     toHHMMSS,
     formatDate,
     getPokemonIcon,
-    arraysEqual
+    arraysEqual,
+    arrayUnique,
 };

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -71,12 +71,6 @@ const formatDate = (date) => {
     return [year, month, day].join('-');
 };
 
-const getPokemonIcon = (pokemonId, formId) => {
-    const padId = (pokemonId + '').padStart(3, '0');
-    const form = formId > 0 ? formId : '00';
-    return util.format(config.urls.images.pokemon, padId, form);
-};
-
 const arraysEqual = (array1, array2) => {
     if (array1 === array2) return true;
     if (array1 == null || array2 == null) return false;
@@ -116,7 +110,6 @@ module.exports = {
     inArray,
     toHHMMSS,
     formatDate,
-    getPokemonIcon,
     arraysEqual,
     arrayUnique,
 };

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -11,13 +11,15 @@ const hasGuild = (guilds) => {
     if (config.discord.guilds.length === 0) {
         return true;
     }
+    let result = false;
     for (let i = 0; i < guilds.length; i++) {
         const guild = guilds[i];
         if (config.discord.guilds.find(x => x.id === guild)) {
-            return true;
+            result = true;
+            break;
         }
     }
-    return false;
+    return result;
 };
 
 const hasRole = (userRoles, requiredRoles) => {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -95,7 +95,7 @@ const arraysEqual = (array1, array2) => {
     return true;
 };
 
-function arrayUnique(array) {
+const arrayUnique = (array) => {
     var newArray = array.concat();
     for (let i = 0; i < newArray.length; i++) {
         for (let j = i + 1; j < newArray.length; j++) {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const util = require('util');
 const config = require('../config.json');
 
 const generateString = () => {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -75,6 +75,26 @@ const getPokemonIcon = (pokemonId, formId) => {
     return util.format(config.urls.images.pokemon, padId, form);
 };
 
+const arraysEqual = (array1, array2) => {
+    if (array1 === array2) return true;
+    if (array1 == null || array2 == null) return false;
+    if (array1.length !== array2.length) return false;
+  
+    // If you don't care about the order of the elements inside
+    // the array, you should sort both arrays here.
+    // Please note that calling sort on an array will modify that array.
+    // you might want to clone your array first.
+    array1.sort();
+    array2.sort();
+  
+    for (let i = 0; i < array1.length; i++) {
+        if (array1[i] !== array2[i]) {
+            return false;
+        }
+    }
+    return true;
+};
+
 module.exports = {
     generateString,
     hasGuild,
@@ -82,5 +102,6 @@ module.exports = {
     inArray,
     toHHMMSS,
     formatDate,
-    getPokemonIcon
+    getPokemonIcon,
+    arraysEqual
 };

--- a/src/views/gym-new.mustache
+++ b/src/views/gym-new.mustache
@@ -11,16 +11,6 @@
             {{Gym Name}}
             <input type="text" class="form-control" name="name" value="" placeholder="i.e. Starbucks">
         </div>
-        <div class="form-group">
-            {{City}}
-            <select name="city" class="custom-select" multiple required>
-                <option value="" selected disabled hidden>{{Choose a City}}</option>
-                <option value="all">All</option>
-                {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" hidden>{{name}}</option>
-                {{/cities}}
-            </select>
-        </div>
         <br>
         <input type="hidden" id="guild_id" name="guild_id">
         <button type="submit" class="btn btn-primary">{{Create}}</button>
@@ -28,11 +18,6 @@
     </form>
 </div>
 
-<script type='text/javascript' src="/js/pokemon-list.js"></script>
 <script type='text/javascript'>
     $('#guild_id').val(guildId);
-    const guilds = document.querySelectorAll('*[id^="g_' + guildId + '"]');
-    if (guilds) {
-        guilds.forEach(guild => guild.hidden = false);
-    }
 </script>

--- a/src/views/invasion-edit.mustache
+++ b/src/views/invasion-edit.mustache
@@ -18,9 +18,8 @@
         </div>
         <div class="form-group">
             {{City}}
-            <select name="city" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a City}}</option>
-                <!--<option value="all">All</option>-->
+            <select name="city" class="custom-select" multiple required>
+                <option value="all" >{{All}}</option>
                 {{#cities}}
                 <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
                 {{/cities}}

--- a/src/views/invasion-edit.mustache
+++ b/src/views/invasion-edit.mustache
@@ -7,6 +7,7 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/invasions/edit/{{id}}" method="post">
+        <!--
         <div class="form-group">
             {{Reward}}
             <select name="reward" class="custom-select">
@@ -16,6 +17,7 @@
                 {{/rewards}}
             </select>
         </div>
+        -->
         <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>

--- a/src/views/invasion-edit.mustache
+++ b/src/views/invasion-edit.mustache
@@ -7,17 +7,6 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/invasions/edit/{{id}}" method="post">
-        <!--
-        <div class="form-group">
-            {{Reward}}
-            <select name="reward" class="custom-select">
-                <option value="" selected disabled hidden>{{Choose a Reward}}</option>
-                {{#rewards}}
-                <option value="{{pokemon_id}}" {{#selected}}selected{{/selected}}>{{name}}</option>
-                {{/rewards}}
-            </select>
-        </div>
-        -->
         <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>

--- a/src/views/invasion-new.mustache
+++ b/src/views/invasion-new.mustache
@@ -15,15 +15,14 @@
             {{Reward}}
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#rewards}}
-                <div class="pokemon-icon-sprite item" id="{{pokemon_id}}" name="{{name}}" data-value="{{pokemon_id}}" onclick="onPokemonClicked(this)">
+                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
                     <img src="{{image_url}}" width="auto" height="48" />
-                    <span class="caption">#{{pokemon_id}}</span>
+                    <span class="caption">#{{id}}</span>
                 </div>
             {{/rewards}}
             </div>
             <input type="hidden" id="pokemon" name="pokemon" />
             <br>
-            <!--<input type="text" class="form-control" placeholder="Search Name or ID" />-->
             <button id="select_all" type="button" class="btn btn-primary btn-sm">{{Select All}}</button>
             <button id="select_none" type="button" class="btn btn-primary btn-sm">{{Select None}}</button>
             <button id="select_gen1" type="button" class="btn btn-warning btn-sm">{{Select Gen1}}</button>

--- a/src/views/invasion-new.mustache
+++ b/src/views/invasion-new.mustache
@@ -16,7 +16,7 @@
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#rewards}}
                 <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
-                    <img src="{{image_url}}" width="auto" height="48" />
+                    <img src="{{image_url}}" width="48" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>
             {{/rewards}}

--- a/src/views/invasion-new.mustache
+++ b/src/views/invasion-new.mustache
@@ -8,10 +8,14 @@
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/invasions/new" method="post">
         <div class="form-group">
+            <div class="form-group">
+                Search
+                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu or 25" onkeyup="onPokemonSearch()">
+            </div>
             {{Reward}}
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#rewards}}
-                <div class="pokemon-icon-sprite item" id="{{pokemon_id}}" name="{{pokemon_id}}" data-value="{{pokemon_id}}" onclick="onPokemonClicked(this)">
+                <div class="pokemon-icon-sprite item" id="{{pokemon_id}}" name="{{name}}" data-value="{{pokemon_id}}" onclick="onPokemonClicked(this)">
                     <img src="{{image_url}}" width="auto" height="48" />
                     <span class="caption">#{{pokemon_id}}</span>
                 </div>

--- a/src/views/pokemon-edit.mustache
+++ b/src/views/pokemon-edit.mustache
@@ -52,11 +52,10 @@
         </div>
         <div class="form-group">
             {{City}}
-            <select name="city" class="custom-select" required>
-                <option value="" selected disabled>{{Choose a City}}</option>
-                <option value="all">All</option>
+            <select name="city" class="custom-select" multiple required>
+                <option value="all" >{{All}}</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}}>{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pokemon-edit.mustache
+++ b/src/views/pokemon-edit.mustache
@@ -7,6 +7,7 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/pokemon/edit/{{id}}" method="post">
+        <!--
         <div class="form-group">
             {{Pokemon}}
             <select name="pokemon" class="custom-select" required>
@@ -16,6 +17,7 @@
                 {{/pokemon}}
             </select>
         </div>
+        -->
         <div class="form-group">
             {{Form}}
             <input type="text" class="form-control" name="form" value="{{form}}" placeholder="i.e. Sunny">

--- a/src/views/pokemon-edit.mustache
+++ b/src/views/pokemon-edit.mustache
@@ -7,17 +7,6 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/pokemon/edit/{{id}}" method="post">
-        <!--
-        <div class="form-group">
-            {{Pokemon}}
-            <select name="pokemon" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a Pokemon}}</option>
-                {{#pokemon}}
-                <option value="{{id}}" {{#selected}}selected{{/selected}}>{{name}}</option>
-                {{/pokemon}}
-            </select>
-        </div>
-        -->
         <div class="form-group">
             {{Form}}
             <input type="text" class="form-control" name="form" value="{{form}}" placeholder="i.e. Sunny">

--- a/src/views/pokemon-edit.mustache
+++ b/src/views/pokemon-edit.mustache
@@ -53,10 +53,10 @@
         <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a City}}</option>
+                <option value="" selected disabled>{{Choose a City}}</option>
                 <option value="all">All</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}}>{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pokemon-new.mustache
+++ b/src/views/pokemon-new.mustache
@@ -64,12 +64,12 @@
                 {{/genders}}
             </select>
         </div>
-        <div class="form-group" hidden>
+        <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>
                 <option value="all" selected>{{All}}</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" hidden>{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}">{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pokemon-new.mustache
+++ b/src/views/pokemon-new.mustache
@@ -8,10 +8,14 @@
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/pokemon/new" method="post">
         <div class="form-group">
+            <div class="form-group">
+                Search
+                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu" onkeyup="onSearchChanged()">
+            </div>
             {{Pokemon}}
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#pokemon}}
-                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{id}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
+                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
                     <img src="{{image_url}}" width="auto" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>
@@ -86,5 +90,14 @@
     const guilds = document.querySelectorAll('*[id^="g_' + guildId + '"]');
     if (guilds) {
         guilds.forEach(guild => guild.hidden = false);
+    }
+    function onSearchChanged() {
+        const pokemon = $('#pokemon-list').children();
+        const search = $('#search').val().toLowerCase();
+        for (let element of pokemon) {
+            const name = element.getAttribute('name');
+            const matches = !name.toLowerCase().includes(search) && search;
+            element.hidden = matches;
+        }
     }
 </script>

--- a/src/views/pokemon-new.mustache
+++ b/src/views/pokemon-new.mustache
@@ -10,7 +10,7 @@
         <div class="form-group">
             <div class="form-group">
                 Search
-                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu" onkeyup="onSearchChanged()">
+                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu or 25" onkeyup="onPokemonSearch()">
             </div>
             {{Pokemon}}
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
@@ -23,7 +23,6 @@
             </div>
             <input type="hidden" id="pokemon" name="pokemon" />
             <br>
-            <!--<input type="text" class="form-control" onkeyup="onSearch(this);" placeholder="Search Name or ID" /><br>-->
             <button id="select_all" type="button" class="btn btn-primary btn-sm">{{Select All}}</button>
             <button id="select_none" type="button" class="btn btn-primary btn-sm">{{Select None}}</button>
             <button id="select_gen1" type="button" class="btn btn-warning btn-sm">{{Select Gen1}}</button>
@@ -90,14 +89,5 @@
     const guilds = document.querySelectorAll('*[id^="g_' + guildId + '"]');
     if (guilds) {
         guilds.forEach(guild => guild.hidden = false);
-    }
-    function onSearchChanged() {
-        const pokemon = $('#pokemon-list').children();
-        const search = $('#search').val().toLowerCase();
-        for (let element of pokemon) {
-            const name = element.getAttribute('name');
-            const matches = !name.toLowerCase().includes(search) && search;
-            element.hidden = matches;
-        }
     }
 </script>

--- a/src/views/pokemon-new.mustache
+++ b/src/views/pokemon-new.mustache
@@ -69,7 +69,7 @@
             <select name="city" class="custom-select" multiple required>
                 <option value="all" selected>{{All}}</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}">{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}" hidden>{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pokemon-new.mustache
+++ b/src/views/pokemon-new.mustache
@@ -16,7 +16,7 @@
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#pokemon}}
                 <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
-                    <img src="{{image_url}}" width="auto" height="48" />
+                    <img src="{{image_url}}" width="48" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>
             {{/pokemon}}

--- a/src/views/pokemon.mustache
+++ b/src/views/pokemon.mustache
@@ -123,7 +123,7 @@
         "order": [[ 0, "asc" ]],
         "search.caseInsensitive": true,
         "columnDefs": [{
-            "targets": [8],
+            "targets": [9],
             "orderable": false
         }],
         "responsive": true

--- a/src/views/pvp-edit.mustache
+++ b/src/views/pvp-edit.mustache
@@ -7,17 +7,6 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/pvp/edit/{{id}}" method="post">
-        <!--
-        <div class="form-group">
-            {{Pokemon}}
-            <select name="pokemon" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a Pokemon}}</option>
-                {{#pokemon}}
-                <option value="{{id}}" {{#selected}}selected{{/selected}}>{{name}}</option>
-                {{/pokemon}}
-            </select>
-        </div>
-        -->
         <div class="form-group">
             {{Form}}
             <input type="text" class="form-control" name="form" value="{{form}}" placeholder="i.e. Sunny">

--- a/src/views/pvp-edit.mustache
+++ b/src/views/pvp-edit.mustache
@@ -7,6 +7,7 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/pvp/edit/{{id}}" method="post">
+        <!--
         <div class="form-group">
             {{Pokemon}}
             <select name="pokemon" class="custom-select" required>
@@ -16,6 +17,7 @@
                 {{/pokemon}}
             </select>
         </div>
+        -->
         <div class="form-group">
             {{Form}}
             <input type="text" class="form-control" name="form" value="{{form}}" placeholder="i.e. Sunny">

--- a/src/views/pvp-edit.mustache
+++ b/src/views/pvp-edit.mustache
@@ -42,7 +42,7 @@
             <select name="city" class="custom-select" required>
                 <option value="all" selected>All</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}}>{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pvp-edit.mustache
+++ b/src/views/pvp-edit.mustache
@@ -39,10 +39,10 @@
         </div>
         <div class="form-group">
             {{City}}
-            <select name="city" class="custom-select" required>
-                <option value="all" selected>All</option>
+            <select name="city" class="custom-select" multiple required>
+                <option value="all" >{{All}}</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}}>{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pvp-new.mustache
+++ b/src/views/pvp-new.mustache
@@ -8,10 +8,14 @@
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/pvp/new" method="post">
         <div class="form-group">
+            <div class="form-group">
+                Search
+                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu or 25" onkeyup="onPokemonSearch()">
+            </div>
             {{Pokemon}}
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#pokemon}}
-                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{id}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
+                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
                     <img src="{{image_url}}" width="auto" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>

--- a/src/views/pvp-new.mustache
+++ b/src/views/pvp-new.mustache
@@ -56,7 +56,7 @@
             <select name="city" class="custom-select" multiple required>
                 <option value="all" selected>{{All}}</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}">{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}" hidden>{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pvp-new.mustache
+++ b/src/views/pvp-new.mustache
@@ -16,7 +16,7 @@
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#pokemon}}
                 <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
-                    <img src="{{image_url}}" width="auto" height="48" />
+                    <img src="{{image_url}}" width="48" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>
             {{/pokemon}}

--- a/src/views/pvp-new.mustache
+++ b/src/views/pvp-new.mustache
@@ -51,12 +51,12 @@
             {{Minimum Percent}}
             <input type="text" class="form-control" name="min_percent" value="" placeholder="i.e. 0-100" min="0", max="100">
         </div>
-        <div class="form-group" hidden>
+        <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>
                 <option value="all" selected>{{All}}</option>
                 {{#cities}}
-                <option value="{{name}}" id="g_{{guild}}" hidden>{{name}}</option>
+                <option value="{{name}}" id="g_{{guild}}">{{name}}</option>
                 {{/cities}}
             </select>
         </div>

--- a/src/views/pvp-new.mustache
+++ b/src/views/pvp-new.mustache
@@ -23,7 +23,6 @@
             </div>
             <input type="hidden" id="pokemon" name="pokemon" />
             <br>
-            <!--<input type="text" class="form-control" placeholder="Search Name or ID" />-->
             <button id="select_all" type="button" class="btn btn-primary btn-sm">{{Select All}}</button>
             <button id="select_none" type="button" class="btn btn-primary btn-sm">{{Select None}}</button>
             <button id="select_gen1" type="button" class="btn btn-warning btn-sm">{{Select Gen1}}</button>

--- a/src/views/quest-edit.mustache
+++ b/src/views/quest-edit.mustache
@@ -7,10 +7,12 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/quests/edit/{{id}}" method="post">
+        <!--
         <div class="form-group">
             {{Reward}}
             <input type="text" class="form-control" name="reward" value="{{reward}}" placeholder="i.e. 500 Stardust" required>
         </div>
+        -->
         <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>

--- a/src/views/quest-edit.mustache
+++ b/src/views/quest-edit.mustache
@@ -7,12 +7,6 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/quests/edit/{{id}}" method="post">
-        <!--
-        <div class="form-group">
-            {{Reward}}
-            <input type="text" class="form-control" name="reward" value="{{reward}}" placeholder="i.e. 500 Stardust" required>
-        </div>
-        -->
         <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>

--- a/src/views/quest-edit.mustache
+++ b/src/views/quest-edit.mustache
@@ -13,9 +13,8 @@
         </div>
         <div class="form-group">
             {{City}}
-            <select name="city" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a City}}</option>
-                <!--<option value="all">All</option>-->
+            <select name="city" class="custom-select" multiple required>
+                <option value="all" >{{All}}</option>
                 {{#cities}}
                 <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
                 {{/cities}}

--- a/src/views/quest-new.mustache
+++ b/src/views/quest-new.mustache
@@ -14,7 +14,7 @@
         <div class="form-group">
             {{City}}
             <select name="city" class="custom-select" multiple required>
-                <option value="all" selected>All</option>
+                <option value="all" selected>{{All}}</option>
                 {{#cities}}
                 <option value="{{name}}" id="g_{{guild}}" hidden>{{name}}</option>
                 {{/cities}}

--- a/src/views/raid-edit.mustache
+++ b/src/views/raid-edit.mustache
@@ -23,9 +23,8 @@
         </div>
         <div class="form-group">
             {{City}}
-            <select name="city" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a City}}</option>
-                <!--<option value="all">All</option>-->
+            <select name="city" class="custom-select" multiple required>
+                <option value="all" >{{All}}</option>
                 {{#cities}}
                 <option value="{{name}}" id="g_{{guild}}" {{#selected}}selected{{/selected}} hidden>{{name}}</option>
                 {{/cities}}

--- a/src/views/raid-edit.mustache
+++ b/src/views/raid-edit.mustache
@@ -7,17 +7,6 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/raids/edit/{{id}}" method="post">
-        <!--
-        <div class="form-group">
-            {{Pokemon}}
-            <select name="pokemon" class="custom-select" required>
-                <option value="" selected disabled hidden>{{Choose a Pokemon}}</option>
-                {{#pokemon}}
-                <option value="{{id}}" {{#selected}}selected{{/selected}}>{{name}}</option>
-                {{/pokemon}}
-            </select>
-        </div>
-        -->
         <div class="form-group">
             {{Form}}
             <input type="text" class="form-control" name="form" value="{{form}}" placeholder="i.e. Sunny">

--- a/src/views/raid-edit.mustache
+++ b/src/views/raid-edit.mustache
@@ -7,16 +7,17 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/raids/edit/{{id}}" method="post">
+        <!--
         <div class="form-group">
             {{Pokemon}}
             <select name="pokemon" class="custom-select" required>
                 <option value="" selected disabled hidden>{{Choose a Pokemon}}</option>
-                <!--<option value="all" selected>All</option>-->
                 {{#pokemon}}
                 <option value="{{id}}" {{#selected}}selected{{/selected}}>{{name}}</option>
                 {{/pokemon}}
             </select>
         </div>
+        -->
         <div class="form-group">
             {{Form}}
             <input type="text" class="form-control" name="form" value="{{form}}" placeholder="i.e. Sunny">

--- a/src/views/raid-new.mustache
+++ b/src/views/raid-new.mustache
@@ -8,10 +8,14 @@
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/raids/new" method="post">
         <div class="form-group">
+            <div class="form-group">
+                Search
+                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu or 25" onkeyup="onPokemonSearch()">
+            </div>
             {{Pokemon}}
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#pokemon}}
-                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{id}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
+                <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
                     <img src="{{image_url}}" width="auto" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>

--- a/src/views/raid-new.mustache
+++ b/src/views/raid-new.mustache
@@ -16,7 +16,7 @@
             <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
             {{#pokemon}}
                 <div class="pokemon-icon-sprite item" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
-                    <img src="{{image_url}}" width="auto" height="48" />
+                    <img src="{{image_url}}" width="48" height="48" />
                     <span class="caption">#{{id}}</span>
                 </div>
             {{/pokemon}}

--- a/src/views/raid-new.mustache
+++ b/src/views/raid-new.mustache
@@ -23,7 +23,6 @@
             </div>
             <input type="hidden" id="pokemon" name="pokemon" />
             <br>
-            <!--<input type="text" class="form-control" placeholder="Search Name or ID" />-->
             <button id="select_all" type="button" class="btn btn-primary btn-sm">{{Select All}}</button>
             <button id="select_none" type="button" class="btn btn-primary btn-sm">{{Select None}}</button>
             <button id="select_gen1" type="button" class="btn btn-warning btn-sm">{{Select Gen1}}</button>

--- a/static/js/pokemon-list.js
+++ b/static/js/pokemon-list.js
@@ -89,7 +89,7 @@ function onPokemonSearch() {
     for (let element of pokemon) {
         const name = element.getAttribute('name');
         const id = element.getAttribute('id');
-        const matches = !name.toLowerCase().includes(search) && !id.toLowerCase().includes(search) && search;
+        const matches = !name.toLowerCase().includes(search) && !id.includes(search) && search;
         element.hidden = matches;
     }
 }

--- a/static/js/pokemon-list.js
+++ b/static/js/pokemon-list.js
@@ -83,11 +83,16 @@ function onPokemonClicked(element) {
     }
 }
 
-/*
-function onSearch(element) {
-    console.log('Search:', element.value);
+function onPokemonSearch() {
+    const pokemon = $('#pokemon-list').children();
+    const search = $('#search').val().toLowerCase();
+    for (let element of pokemon) {
+        const name = element.getAttribute('name');
+        const id = element.getAttribute('id');
+        const matches = !name.toLowerCase().includes(search) && !id.toLowerCase().includes(search) && search;
+        element.hidden = matches;
+    }
 }
-*/
 
 function selectItem(element) {
     if (!element.classList.value.includes('active')) {


### PR DESCRIPTION
Fixes: #11 
Fixes: #12 
- Allows subscriptions for Pokemon and PvP for specific cities instead of relying on assigned Discord roles.
- Combine subscription entries instead of separate per city
- Add search to Pokemon listings
- Fix issue with role check if user isn't in all guilds configured
- Lots of bug fixes