### PR TITLE
fix: Allow Safari on iOS and mac to select on map

### DIFF
--- a/src/views/header.mustache
+++ b/src/views/header.mustache
@@ -8,7 +8,7 @@
 
     <link rel='shortcut icon' type='image/x-icon' href='./static/favicon.ico' />
     <link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css' integrity='sha256-eSi1q2PG6J7g7ib17yAaWMcrr5GrtohYChqibrV7PBE=' crossorigin='anonymous' />
-    <link rel='stylesheet' type='text/css' href='https://unpkg.com/leaflet@1.7.1/dist/leaflet.css' integrity='sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==' crossorigin='' />
+    <link rel='stylesheet' type='text/css' href='https://unpkg.com/leaflet@1.7.0/dist/leaflet.css' integrity='sha384-VzLXTJGPSyTLX6d96AxgkKvE/LRb7ECGyTxuwtpjHnVWVZs2gp5RDjeM/tgBnVdM' crossorigin='' />
     <!--<link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css' />-->
     <link rel='stylesheet' type='text/css' href='https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@v0.70.0/dist/L.Control.Locate.min.css' />
     <link rel='stylesheet' type='text/css' href='https://cdn.datatables.net/v/bs4/dt-1.10.20/b-1.6.1/cr-1.5.2/fh-3.1.6/r-2.2.3/sc-2.0.1/datatables.min.css' />
@@ -25,7 +25,7 @@
     <script type='text/javascript' src='https://cdn.datatables.net/v/bs4/dt-1.10.20/b-1.6.1/cr-1.5.2/fh-3.1.6/r-2.2.3/sc-2.0.1/datatables.min.js'></script>
     <script type='text/javascript' src='https://cdn.datatables.net/buttons/1.6.1/js/buttons.colVis.min.js'></script>
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/flatpickr'></script>
-    <script type='text/javascript' src='https://unpkg.com/leaflet@1.7.1/dist/leaflet.js' integrity='sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==' crossorigin=''></script>
+    <script type='text/javascript' src='https://unpkg.com/leaflet@1.7.0/dist/leaflet.js' integrity='sha384-UYn5aDdnSToqO3lXMktQ9F7ttldUeadL5sfPHthwvpFfeV5tzIgztARkF7nG52LK' crossorigin=''></script>
     <!--<script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.js'></script>-->
     <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@v0.70.0/dist/L.Control.Locate.min.js' charset='utf-8'></script>
     <script type='text/javascript' src='../../js/storage.js'></script>

--- a/static/js/city-map.js
+++ b/static/js/city-map.js
@@ -7,6 +7,7 @@ let initialSelect = [];
 
 function initMap(startLocation, startZoom, minZoom, maxZoom, tileserver, selected = []) {
     const map = L.map('map', {
+        tap: false,
         preferCanvas: true,
         //worldCopyJump: true,
         updateWhenIdle: true,

--- a/static/js/location-selector.js
+++ b/static/js/location-selector.js
@@ -16,6 +16,7 @@ $('#distance').change(function(e) {
 
 function initMap(startLocation, startZoom, minZoom, maxZoom, tileserver, location = null, radius = 1000) {
     const map = L.map('map', {
+        tap: false,
         preferCanvas: true,
         //worldCopyJump: true,
         updateWhenIdle: true,

--- a/static/js/location-viewer.js
+++ b/static/js/location-viewer.js
@@ -4,6 +4,7 @@ let circleMarker;
 
 function initMap(startLocation, startZoom, minZoom, maxZoom, tileserver, location = null, radius = 1000) {
     const map = L.map('map', {
+        tap: false,
         preferCanvas: true,
         //worldCopyJump: true,
         updateWhenIdle: true,


### PR DESCRIPTION
Fixes: #48

Reference to current bug in Leaflet 1.7.1 https://github.com/domoritz/leaflet-locatecontrol#safari-does-not-work-with-leaflet-171

Confirmed on:
* Big Sur 11.4 Safari
* iOS 14.recent Safari
* Big Sur Chrome 91.XX

This should be fine but please double check. Also hate your windows line endings <3