### PR TITLE
Add support for multiple invasion reward subscriptions

### DIFF
--- a/src/models/invasion.js
+++ b/src/models/invasion.js
@@ -37,14 +37,14 @@ class Invasion extends Model {
         return Invasion.findByPk(id);
     }
 
-    static getBy(guildId, userId, pokestopName, gruntType, rewardPokemonId) {
+    static getBy(guildId, userId, pokestopName, gruntType, rewardPokemonIds) {
         return Invasion.findOne({
             where: {
                 guildId: guildId,
                 userId: userId,
                 pokestopName: pokestopName,
                 gruntType: gruntType,
-                rewardPokemonId: rewardPokemonId,
+                rewardPokemonId: rewardPokemonIds,
             }
         });
     }
@@ -106,7 +106,7 @@ Invasion.init({
         allowNull: true,
     },
     rewardPokemonId: {
-        type: DataTypes.INTEGER(11).UNSIGNED,
+        type: DataTypes.TEXT(),
         allowNull: true,
     },
     city: {

--- a/src/models/invasion.js
+++ b/src/models/invasion.js
@@ -107,7 +107,7 @@ Invasion.init({
     },
     rewardPokemonId: {
         type: DataTypes.TEXT(),
-        allowNull: true,
+        defaultValue: null,
     },
     city: {
         type: DataTypes.JSON,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -984,7 +984,7 @@ router.post('/invasion/new', async (req, res) => {
             userId: user_id,
             pokestopName: name || null,
             gruntType: grunt_type || null,
-            rewardPokemonId: pokemonId || null,
+            rewardPokemonId: pokemon || null,
             city: areas,
             location: location || null,
         });

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -188,7 +188,7 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
                 for (let invasion of invasions) {
                     invasion = invasion.toJSON();
                     const ids = (invasion.rewardPokemonId || '').split(',').sort((a, b) => a - b);
-                    const icons = [];
+                    let icons = [];
                     const maxIcons = 8;
                     if (ids.length === 1) {
                         const id = ids[0];

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -187,16 +187,18 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
             if (invasions) {
                 for (let invasion of invasions) {
                     invasion = invasion.toJSON();
-                    const ids = invasion.rewardPokemonId.split(',').sort((a, b) => a - b);
+                    const ids = (invasion.rewardPokemonId || '').split(',').sort((a, b) => a - b);
                     const icons = [];
                     const maxIcons = 8;
                     if (ids.length === 1) {
                         const id = ids[0];
-                        const name = Localizer.getPokemonName(id);
-                        const icon = await Localizer.getPokemonIcon(id);
-                        const url = `<img src='${icon}' width='auto' height='32'>&nbsp;${name}`;
-                        icons.push(url);
-                    } else  {
+                        if (id !== '') {
+                            const name = Localizer.getPokemonName(id);
+                            const icon = await Localizer.getPokemonIcon(id);
+                            const url = `<img src='${icon}' width='auto' height='32'>&nbsp;${name}`;
+                            icons.push(url);
+                        }
+                    } else if (ids.length > 1) {
                         for (const [index, id] of ids.entries()) {
                             const icon = await Localizer.getPokemonIcon(id);
                             const url = `<img src='${icon}' width='auto' height='32'>&nbsp;`;
@@ -206,9 +208,11 @@ router.post('/server/:guild_id/user/:user_id', async (req, res) => {
                                 break;
                             }
                         }
+                    } else {
+                        icons = [];
                     }
                     invasion.name = invasion.pokestopName;
-                    invasion.reward = icons.join(' ');
+                    invasion.reward = icons.join(' ') || null;
                     invasion.type = invasion.gruntType ? Localizer.getInvasionName(invasion.gruntType) : '';
                     invasion.city = formatAreas(guild_id, invasion.city);
                     invasion.buttons = `

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -395,6 +395,7 @@ router.get('/invasion/edit/:id', async (req, res) => {
     data.rewards.forEach(reward => {
         reward.selected = reward.id === invasion.rewardPokemonId;
     });
+    data.pokemon_ids = invasion.rewardPokemonId;
     const cities = getSelectedAreas(
         // Current guild
         invasion.guildId,

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -91,7 +91,7 @@ const arraysEqual = (array1, array2) => {
 };
 
 const arrayUnique = (array) => {
-    var newArray = array.concat();
+    let newArray = array.concat();
     for (let i = 0; i < newArray.length; i++) {
         for (let j = i + 1; j < newArray.length; j++) {
             if (newArray[i] === newArray[j]) {

--- a/src/views/invasions/edit.mustache
+++ b/src/views/invasions/edit.mustache
@@ -12,6 +12,34 @@
 <br>
 <div class="w-75" style="float: none; margin: 0 auto;">
     <form action="/api/invasions/edit/{{id}}" method="post">
+        <div class="form-group">
+            <div class="form-group">
+                {{Search}}
+                <input type="text" class="form-control" id="search" value="" placeholder="i.e Pikachu or 25" onkeyup="onPokemonSearch()">
+            </div>
+            {{Pokemon}}
+            <div id="pokemon-list" name="pokemon-list" class="pokemon-list custom-control">
+            {{#pokemon}}
+                <div class="pokemon-icon-sprite item {{#selected}}active{{/selected}}" style="{{#selected}}background-color: dodgerblue;{{/selected}}" id="{{id}}" name="{{name}}" data-value="{{id}}" onclick="onPokemonClicked(this)">
+                    <img src="{{image_url}}" width="48" height="48" />
+                    <span class="caption">#{{id}}</span>
+                </div>
+            {{/pokemon}}
+            </div>
+            <input type="text" id="pokemon" name="pokemon" value="{{pokemon_ids}}" />
+            <br>
+            <button id="select_all" type="button" class="btn btn-primary btn-sm">{{Select All}}</button>
+            <button id="select_none" type="button" class="btn btn-primary btn-sm">{{Select None}}</button>
+            <button id="select_invert" type="button" class="btn btn-primary btn-sm">{{Invert Selection}}</button>
+            <button id="select_gen1" type="button" class="btn btn-warning btn-sm">{{Select Gen1}}</button>
+            <button id="select_gen2" type="button" class="btn btn-warning btn-sm">{{Select Gen2}}</button>
+            <button id="select_gen3" type="button" class="btn btn-warning btn-sm">{{Select Gen3}}</button>
+            <button id="select_gen4" type="button" class="btn btn-warning btn-sm">{{Select Gen4}}</button>
+            <button id="select_gen5" type="button" class="btn btn-warning btn-sm">{{Select Gen5}}</button>
+            <button id="select_gen6" type="button" class="btn btn-warning btn-sm">{{Select Gen6}}</button>
+            <button id="select_rare" type="button" class="btn btn-success btn-sm">{{Select Rare}}</button>
+            <button id="select_ultra" type="button" class="btn btn-danger btn-sm">{{Select Ultra Rare}}</button>
+        </div>
         {{Pokestop Name}}
         <input list="pokestop-names" class="custom-select" name="name" id="name" value="{{name}}">
         <datalist id="pokestop-names">


### PR DESCRIPTION
Adds support for creating multiple invasion Pokemon reward subscriptions while maintaining the same subscription instead of creating one per each Pokemon.

![image](https://user-images.githubusercontent.com/1327440/120814487-c542df80-c503-11eb-859c-0c4bbc51ad0f.png)
