### PR TITLE
Fix initial user subscription

### DIFF
--- a/src/models/subscription.js
+++ b/src/models/subscription.js
@@ -21,7 +21,7 @@ const NotificationStatusType = {
     Invasions: 0x10,
     Lures: 0x20,
     Gyms: 0x40,
-    All: this.Pokemon | this.PvP | this.Raids | this.Quests | this.Invasions | this.Lures | this.Gyms,
+    All: NotificationStatusType.Pokemon | NotificationStatusType.PvP | NotificationStatusType.Raids | NotificationStatusType.Quests | NotificationStatusType.Invasions | NotificationStatusType.Lures | NotificationStatusType.Gyms,
 };
 
 class Subscription extends Model {


### PR DESCRIPTION
We were setting new subscriptions to a status code of 0 instead of 127. Can be seen locally with:

```node
$ node
var NotificationStatusType = {
    None: 0x0,
    Pokemon: 0x1,
    PvP: 0x2,
    Raids: 0x4,
    Quests: 0x8,
    Invasions: 0x10,
    Lures: 0x20,
    Gyms: 0x40,
    All: this.Pokemon | this.PvP | this.Raids | this.Quests | this.Invasions | this.Lures | this.Gyms,
};

> NotificationStatusType.All
0

var NotificationStatusType = {
    None: 0x0,
    Pokemon: 0x1,
    PvP: 0x2,
    Raids: 0x4,
    Quests: 0x8,
    Invasions: 0x10,
    Lures: 0x20,
    Gyms: 0x40,
    All: NotificationStatusType.Pokemon | NotificationStatusType.PvP | NotificationStatusType.Raids | NotificationStatusType.Quests | NotificationStatusType.Invasions | NotificationStatusType.Lures | NotificationStatusType.Gyms,
};

> NotificationStatusType.All
127
``` 