### PR TITLE
fix: Better end user handling

### DIFF
--- a/src/views/locations/edit.mustache
+++ b/src/views/locations/edit.mustache
@@ -27,6 +27,10 @@
         <br>
         <button type="submit" class="btn btn-primary">{{Save}}</button>
         <br>
+        <br>
+        <div id="error-div" class="alert alert-danger" style="float: none; margin: 0 auto;" hidden>
+        </div>
+        <br>
     </form>
 </div>
 

--- a/src/views/locations/new.mustache
+++ b/src/views/locations/new.mustache
@@ -27,6 +27,10 @@
         <br>
         <button type="submit" class="btn btn-primary">{{Create}}</button>
         <br>
+        <br>
+        <div id="error-div" class="alert alert-danger" style="float: none; margin: 0 auto;" hidden>
+        </div>
+        <br>
     </form>
 </div>
 

--- a/static/js/location-selector.js
+++ b/static/js/location-selector.js
@@ -5,6 +5,16 @@ let initialLocation;
 let lastLocation;
 let circleMarker;
 
+$('form').submit(function(e) {
+    const location = $('#location').val();
+    if (location == '') {
+        // Show error message about invalid location
+        $('#error-div').prop('hidden', false);
+        $('#error-div').html('<div><strong>Error!</strong> Click on map to create your location.</div>');
+        e.preventDefault();
+    }
+});
+
 // TODO: Maybe upon location found, set circle position.
 
 $('#distance').change(function(e) {

--- a/static/js/pokemon-list.js
+++ b/static/js/pokemon-list.js
@@ -1,4 +1,15 @@
 let pokemonRarity = {};
+
+$('form').submit(function(e) {
+    const pokemon = $('#pokemon').val();
+    if (pokemon == '') {
+        // Show error message about pokemon selection
+        $('#error-div').prop('hidden', false);
+        $('#error-div').html('<div><strong>Error!</strong> Please select one or more pokemon.</div>');
+        e.preventDefault();
+    }
+});
+
 $.getJSON('/data/rarity.json', function(data) {
     pokemonRarity = data;
 });


### PR DESCRIPTION
* Make sure user clicks on the location before trying to save
* Fixes pokemon & pvp subscriptions so we don’t write empty pokemon_id to database.

ISSUE: currently this doesn’t work well for the Invasions page. Should have a check to see if grunt_type exists OR pokemon(s) are select. I couldn’t figure out how to make that work.

Feel free to dump this code and do it better.